### PR TITLE
Add cuda-internal.ads

### DIFF
--- a/api/cuda_api/cuda-internal.ads
+++ b/api/cuda_api/cuda-internal.ads
@@ -1,0 +1,53 @@
+with System;
+with Interfaces.C.Strings;
+with CUDA.Vector_Types;
+with CUDA.Crtdefs;
+with CUDA.Driver_Types;
+
+package CUDA.Internal is
+
+   procedure Register_Function
+      (Fat_Binary_Handle : System.Address;
+       Func : System.Address;
+       Kernel_Name : Interfaces.C.Strings.chars_ptr;
+       Kernel_Name_2 : Interfaces.C.Strings.chars_ptr;
+       Minus_One : Integer;
+       Nullptr1 : System.Address;
+       Nullptr2 : System.Address;
+       Nullptr3 : System.Address;
+       Nullptr4 : System.Address;
+       Nullptr5 : System.Address)
+      with Import => True,
+           Convention => C,
+           External_Name => "__cudaRegisterFunction";
+
+   function Register_Fat_Binary (Fat_Binary : System.Address)
+      return System.Address
+      with Import => True,
+           Convention => C,
+           External_Name => "__cudaRegisterFatBinary";
+
+   procedure Register_Fat_Binary_End (Fat_Binary : System.Address)
+      with Import => True,
+           Convention => C,
+           External_Name => "__cudaRegisterFatBinaryEnd";
+
+   procedure Push_Call_Configuration
+      (Grid_Dim : Vector_Types.Dim3;
+       Block_Dim : Vector_Types.Dim3;
+       Shared_Mem : Crtdefs.Size_T;
+       Stream : Driver_Types.Stream_T)
+       with Import => True,
+            Convention => C,
+            External_Name => "__cudaPushCallConfiguration";
+
+   procedure Pop_Call_Configuration
+      (Grid_Dim : System.Address;
+       Block_Dim : System.Address;
+       Shared_Mem : System.Address;
+       Stream : System.Address)
+       with Import => True,
+            Convention => C,
+            External_Name => "__cudaPopCallConfiguration";
+
+end CUDA.Internal;


### PR DESCRIPTION
This file provides bindings for undocumented functions of the CUDA
Runtime API which are necessary to interact with the GPU.
The name of the arguments will be improved once I figure out what
they're supposed to do.