### PR TITLE
Update vectorAdd example to work with new bindings

### DIFF
--- a/api/cuda_api/cuda-crtdefs.ads
+++ b/api/cuda_api/cuda-crtdefs.ads
@@ -1,0 +1,3 @@
+with CUDA.Corecrt;
+
+package CUDA.Crtdefs renames CUDA.Corecrt;

--- a/api/cuda_api/cuda-driver_types.adb
+++ b/api/cuda_api/cuda-driver_types.adb
@@ -1,4 +1,3 @@
-with crtdefs_h;
 with driver_types_h;
 with vector_types_h;
 

--- a/api/cuda_api/cuda-driver_types.ads
+++ b/api/cuda_api/cuda-driver_types.ads
@@ -1,5 +1,8 @@
 with Interfaces.C; use Interfaces.C;
 with System;
+with CUDA.Corecrt;
+with CUDA.Vector_Types;
+with Interfaces.C.Extensions;
 
 package CUDA.Driver_Types is
    pragma Elaborate_Body;
@@ -222,7 +225,6 @@ package CUDA.Driver_Types is
    end record;
 
    type Memcpy3_DPeer_Parms is record
-<<<<<<< HEAD
       Src_Array  : CUDA_Array_t;
       Src_Pos    : Pos;
       Src_Ptr    : Pitched_Ptr;
@@ -244,29 +246,6 @@ package CUDA.Driver_Types is
    end record;
 
    type Host_Fn_T is access procedure (arg1 : System.Address);
-=======
-      Src_Array  : CUDA_Array_T;
-      Src_Pos    : aliased Pos;
-      Src_Ptr    : aliased Pitched_Ptr;
-      Src_Device : aliased Interfaces.C.int;
-      Dst_Array  : CUDA_Array_T;
-      Dst_Pos    : aliased Pos;
-      Dst_Ptr    : aliased Pitched_Ptr;
-      Dst_Device : aliased Interfaces.C.int;
-      Extent     : aliased Extent_T;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Memset_Params is record
-      Dst          : System.Address;
-      Pitch        : aliased CUDA.Crtdefs.Size_T;
-      Value        : aliased Interfaces.C.unsigned;
-      Element_Size : aliased Interfaces.C.unsigned;
-      Width        : aliased CUDA.Crtdefs.Size_T;
-      Height       : aliased CUDA.Crtdefs.Size_T;
-   end record with
-      Convention => C_Pass_By_Copy;
->>>>>>> temporary_branch
 
    generic
       with procedure Temp_1 (Arg1 : System.Address);
@@ -286,21 +265,12 @@ package CUDA.Driver_Types is
       Stream_Capture_Mode_Relaxed);
 
    type Graphics_Resource is null record;
-<<<<<<< HEAD
-   subtype Graphics_Register_Flags is unsigned;
-   Graphics_Register_Flags_None               : unsigned;
-   Graphics_Register_Flags_Read_Only          : unsigned;
-   Graphics_Register_Flags_Write_Discard      : unsigned;
-   Graphics_Register_Flags_Surface_Load_Store : unsigned;
-   Graphics_Register_Flags_Texture_Gather     : unsigned;
-=======
    subtype Graphics_Register_Flags is Interfaces.C.unsigned;
    Graphics_Register_Flags_None               : constant Interfaces.C.unsigned := 0;
    Graphics_Register_Flags_Read_Only          : constant Interfaces.C.unsigned := 1;
    Graphics_Register_Flags_Write_Discard      : constant Interfaces.C.unsigned := 2;
    Graphics_Register_Flags_Surface_Load_Store : constant Interfaces.C.unsigned := 4;
    Graphics_Register_Flags_Texture_Gather     : constant Interfaces.C.unsigned := 8;
->>>>>>> temporary_branch
 
    type Graphics_Map_Flags is
      (Graphics_Map_Flags_None, Graphics_Map_Flags_Read_Only,
@@ -354,7 +324,6 @@ package CUDA.Driver_Types is
 
    type Anon985_Struct990 is record
       Dev_Ptr        : System.Address;
-<<<<<<< HEAD
       Desc           : Channel_Format_Desc;
       Width          : CUDA.Corecrt.Size_T;
       Height         : CUDA.Corecrt.Size_T;
@@ -367,32 +336,6 @@ package CUDA.Driver_Types is
       Linear   : Anon985_Struct989;
       Pitch2_D : Anon985_Struct990;
    end record;
-=======
-      Desc           : aliased Channel_Format_Desc;
-      Width          : aliased CUDA.Crtdefs.Size_T;
-      Height         : aliased CUDA.Crtdefs.Size_T;
-      Pitch_In_Bytes : aliased CUDA.Crtdefs.Size_T;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon985_Res_Union (discr : Interfaces.C.unsigned := 0) is record
-      case discr is
-         when 0 =>
-            C_Array : aliased Anon985_C_Array_Struct;
-
-         when 1 =>
-            Mipmap : aliased Anon985_Mipmap_Struct;
-
-         when 2 =>
-            Linear : aliased Anon985_Linear_Struct;
-
-         when others =>
-            Pitch2_D : aliased Anon985_Pitch2_D_Struct;
-      end case;
-   end record with
-      Convention      => C_Pass_By_Copy,
-      Unchecked_Union => True;
->>>>>>> temporary_branch
 
    type Resource_Desc is record
       Res_Type : Resource_Type;
@@ -400,7 +343,6 @@ package CUDA.Driver_Types is
    end record;
 
    type Resource_View_Desc is record
-<<<<<<< HEAD
       Format             : Resource_View_Format;
       Width              : CUDA.Corecrt.Size_T;
       Height             : CUDA.Corecrt.Size_T;
@@ -436,52 +378,11 @@ package CUDA.Driver_Types is
    Func_Attribute_Max_Dynamic_Shared_Memory_Size   : unsigned;
    Func_Attribute_Preferred_Shared_Memory_Carveout : unsigned;
    Func_Attribute_Max                              : unsigned;
-=======
-      Format             : aliased Resource_View_Format;
-      Width              : aliased CUDA.Crtdefs.Size_T;
-      Height             : aliased CUDA.Crtdefs.Size_T;
-      Depth              : aliased CUDA.Crtdefs.Size_T;
-      First_Mipmap_Level : aliased Interfaces.C.unsigned;
-      Last_Mipmap_Level  : aliased Interfaces.C.unsigned;
-      First_Layer        : aliased Interfaces.C.unsigned;
-      Last_Layer         : aliased Interfaces.C.unsigned;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Pointer_Attributes is record
-      Memory_Type    : aliased Memory_Type_T;
-      C_Type         : aliased Memory_Type_T;
-      Device         : aliased Interfaces.C.int;
-      Device_Pointer : System.Address;
-      Host_Pointer   : System.Address;
-      Is_Managed     : aliased Interfaces.C.int;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Func_Attributes is record
-      Shared_Size_Bytes             : aliased CUDA.Crtdefs.Size_T;
-      Const_Size_Bytes              : aliased CUDA.Crtdefs.Size_T;
-      Local_Size_Bytes              : aliased CUDA.Crtdefs.Size_T;
-      Max_Threads_Per_Block         : aliased Interfaces.C.int;
-      Num_Regs                      : aliased Interfaces.C.int;
-      Ptx_Version                   : aliased Interfaces.C.int;
-      Binary_Version                : aliased Interfaces.C.int;
-      Cache_Mode_CA                 : aliased Interfaces.C.int;
-      Max_Dynamic_Shared_Size_Bytes : aliased Interfaces.C.int;
-      Preferred_Shmem_Carveout      : aliased Interfaces.C.int;
-   end record with
-      Convention => C_Pass_By_Copy;
-   subtype Func_Attribute is Interfaces.C.unsigned;
-   Func_Attribute_Max_Dynamic_Shared_Memory_Size   : constant Interfaces.C.unsigned := 8;
-   Func_Attribute_Preferred_Shared_Memory_Carveout : constant Interfaces.C.unsigned := 9;
-   Func_Attribute_Max                              : constant Interfaces.C.unsigned := 10;
->>>>>>> temporary_branch
 
    type Func_Cache is
      (Func_Cache_Prefer_None, Func_Cache_Prefer_Shared, Func_Cache_Prefer_L1,
       Func_Cache_Prefer_Equal);
 
-<<<<<<< HEAD
    type Shared_Mem_Config is
      (Shared_Mem_Bank_Size_Default, Shared_Mem_Bank_Size_Four_Byte,
       Shared_Mem_Bank_Size_Eight_Byte);
@@ -619,145 +520,12 @@ package CUDA.Driver_Types is
    Dev_P2_PAttr_Native_Atomic_Supported     : unsigned;
    Dev_P2_PAttr_Cuda_Array_Access_Supported : unsigned;
    subtype Anon1005_Array1007 is Interfaces.C.char_array (0 .. 15);
-=======
-   type Shared_Mem_Config is (Shared_Mem_Bank_Size_Default, Shared_Mem_Bank_Size_Four_Byte, Shared_Mem_Bank_Size_Eight_Byte) with
-      Convention => C;
-
-   type Compute_Mode is (Compute_Mode_Default, Compute_Mode_Exclusive, Compute_Mode_Prohibited, Compute_Mode_Exclusive_Process) with
-      Convention => C;
-
-   type Limit is (Limit_Stack_Size, Limit_Printf_Fifo_Size, Limit_Malloc_Heap_Size, Limit_Dev_Runtime_Sync_Depth, Limit_Dev_Runtime_Pending_Launch_Count, Limit_Max_L2_Fetch_Granularity) with
-      Convention => C;
-   subtype Memory_Advise is Interfaces.C.unsigned;
-   Mem_Advise_Set_Read_Mostly          : constant Interfaces.C.unsigned := 1;
-   Mem_Advise_Unset_Read_Mostly        : constant Interfaces.C.unsigned := 2;
-   Mem_Advise_Set_Preferred_Location   : constant Interfaces.C.unsigned := 3;
-   Mem_Advise_Unset_Preferred_Location : constant Interfaces.C.unsigned := 4;
-   Mem_Advise_Set_Accessed_By          : constant Interfaces.C.unsigned := 5;
-   Mem_Advise_Unset_Accessed_By        : constant Interfaces.C.unsigned := 6;
-   subtype Mem_Range_Attribute is Interfaces.C.unsigned;
-   Mem_Range_Attribute_Read_Mostly            : constant Interfaces.C.unsigned := 1;
-   Mem_Range_Attribute_Preferred_Location     : constant Interfaces.C.unsigned := 2;
-   Mem_Range_Attribute_Accessed_By            : constant Interfaces.C.unsigned := 3;
-   Mem_Range_Attribute_Last_Prefetch_Location : constant Interfaces.C.unsigned := 4;
-
-   type Output_Mode is (Key_Value_Pair, CSV) with
-      Convention => C;
-   subtype Device_Attr is Interfaces.C.unsigned;
-   Dev_Attr_Max_Threads_Per_Block                        : constant Interfaces.C.unsigned := 1;
-   Dev_Attr_Max_Block_Dim_X                              : constant Interfaces.C.unsigned := 2;
-   Dev_Attr_Max_Block_Dim_Y                              : constant Interfaces.C.unsigned := 3;
-   Dev_Attr_Max_Block_Dim_Z                              : constant Interfaces.C.unsigned := 4;
-   Dev_Attr_Max_Grid_Dim_X                               : constant Interfaces.C.unsigned := 5;
-   Dev_Attr_Max_Grid_Dim_Y                               : constant Interfaces.C.unsigned := 6;
-   Dev_Attr_Max_Grid_Dim_Z                               : constant Interfaces.C.unsigned := 7;
-   Dev_Attr_Max_Shared_Memory_Per_Block                  : constant Interfaces.C.unsigned := 8;
-   Dev_Attr_Total_Constant_Memory                        : constant Interfaces.C.unsigned := 9;
-   Dev_Attr_Warp_Size                                    : constant Interfaces.C.unsigned := 10;
-   Dev_Attr_Max_Pitch                                    : constant Interfaces.C.unsigned := 11;
-   Dev_Attr_Max_Registers_Per_Block                      : constant Interfaces.C.unsigned := 12;
-   Dev_Attr_Clock_Rate                                   : constant Interfaces.C.unsigned := 13;
-   Dev_Attr_Texture_Alignment                            : constant Interfaces.C.unsigned := 14;
-   Dev_Attr_Gpu_Overlap                                  : constant Interfaces.C.unsigned := 15;
-   Dev_Attr_Multi_Processor_Count                        : constant Interfaces.C.unsigned := 16;
-   Dev_Attr_Kernel_Exec_Timeout                          : constant Interfaces.C.unsigned := 17;
-   Dev_Attr_Integrated                                   : constant Interfaces.C.unsigned := 18;
-   Dev_Attr_Can_Map_Host_Memory                          : constant Interfaces.C.unsigned := 19;
-   Dev_Attr_Compute_Mode                                 : constant Interfaces.C.unsigned := 20;
-   Dev_Attr_Max_Texture1_DWidth                          : constant Interfaces.C.unsigned := 21;
-   Dev_Attr_Max_Texture2_DWidth                          : constant Interfaces.C.unsigned := 22;
-   Dev_Attr_Max_Texture2_DHeight                         : constant Interfaces.C.unsigned := 23;
-   Dev_Attr_Max_Texture3_DWidth                          : constant Interfaces.C.unsigned := 24;
-   Dev_Attr_Max_Texture3_DHeight                         : constant Interfaces.C.unsigned := 25;
-   Dev_Attr_Max_Texture3_DDepth                          : constant Interfaces.C.unsigned := 26;
-   Dev_Attr_Max_Texture2_DLayered_Width                  : constant Interfaces.C.unsigned := 27;
-   Dev_Attr_Max_Texture2_DLayered_Height                 : constant Interfaces.C.unsigned := 28;
-   Dev_Attr_Max_Texture2_DLayered_Layers                 : constant Interfaces.C.unsigned := 29;
-   Dev_Attr_Surface_Alignment                            : constant Interfaces.C.unsigned := 30;
-   Dev_Attr_Concurrent_Kernels                           : constant Interfaces.C.unsigned := 31;
-   Dev_Attr_Ecc_Enabled                                  : constant Interfaces.C.unsigned := 32;
-   Dev_Attr_Pci_Bus_Id                                   : constant Interfaces.C.unsigned := 33;
-   Dev_Attr_Pci_Device_Id                                : constant Interfaces.C.unsigned := 34;
-   Dev_Attr_Tcc_Driver                                   : constant Interfaces.C.unsigned := 35;
-   Dev_Attr_Memory_Clock_Rate                            : constant Interfaces.C.unsigned := 36;
-   Dev_Attr_Global_Memory_Bus_Width                      : constant Interfaces.C.unsigned := 37;
-   Dev_Attr_L2_Cache_Size                                : constant Interfaces.C.unsigned := 38;
-   Dev_Attr_Max_Threads_Per_Multi_Processor              : constant Interfaces.C.unsigned := 39;
-   Dev_Attr_Async_Engine_Count                           : constant Interfaces.C.unsigned := 40;
-   Dev_Attr_Unified_Addressing                           : constant Interfaces.C.unsigned := 41;
-   Dev_Attr_Max_Texture1_DLayered_Width                  : constant Interfaces.C.unsigned := 42;
-   Dev_Attr_Max_Texture1_DLayered_Layers                 : constant Interfaces.C.unsigned := 43;
-   Dev_Attr_Max_Texture2_DGather_Width                   : constant Interfaces.C.unsigned := 45;
-   Dev_Attr_Max_Texture2_DGather_Height                  : constant Interfaces.C.unsigned := 46;
-   Dev_Attr_Max_Texture3_DWidth_Alt                      : constant Interfaces.C.unsigned := 47;
-   Dev_Attr_Max_Texture3_DHeight_Alt                     : constant Interfaces.C.unsigned := 48;
-   Dev_Attr_Max_Texture3_DDepth_Alt                      : constant Interfaces.C.unsigned := 49;
-   Dev_Attr_Pci_Domain_Id                                : constant Interfaces.C.unsigned := 50;
-   Dev_Attr_Texture_Pitch_Alignment                      : constant Interfaces.C.unsigned := 51;
-   Dev_Attr_Max_Texture_Cubemap_Width                    : constant Interfaces.C.unsigned := 52;
-   Dev_Attr_Max_Texture_Cubemap_Layered_Width            : constant Interfaces.C.unsigned := 53;
-   Dev_Attr_Max_Texture_Cubemap_Layered_Layers           : constant Interfaces.C.unsigned := 54;
-   Dev_Attr_Max_Surface1_DWidth                          : constant Interfaces.C.unsigned := 55;
-   Dev_Attr_Max_Surface2_DWidth                          : constant Interfaces.C.unsigned := 56;
-   Dev_Attr_Max_Surface2_DHeight                         : constant Interfaces.C.unsigned := 57;
-   Dev_Attr_Max_Surface3_DWidth                          : constant Interfaces.C.unsigned := 58;
-   Dev_Attr_Max_Surface3_DHeight                         : constant Interfaces.C.unsigned := 59;
-   Dev_Attr_Max_Surface3_DDepth                          : constant Interfaces.C.unsigned := 60;
-   Dev_Attr_Max_Surface1_DLayered_Width                  : constant Interfaces.C.unsigned := 61;
-   Dev_Attr_Max_Surface1_DLayered_Layers                 : constant Interfaces.C.unsigned := 62;
-   Dev_Attr_Max_Surface2_DLayered_Width                  : constant Interfaces.C.unsigned := 63;
-   Dev_Attr_Max_Surface2_DLayered_Height                 : constant Interfaces.C.unsigned := 64;
-   Dev_Attr_Max_Surface2_DLayered_Layers                 : constant Interfaces.C.unsigned := 65;
-   Dev_Attr_Max_Surface_Cubemap_Width                    : constant Interfaces.C.unsigned := 66;
-   Dev_Attr_Max_Surface_Cubemap_Layered_Width            : constant Interfaces.C.unsigned := 67;
-   Dev_Attr_Max_Surface_Cubemap_Layered_Layers           : constant Interfaces.C.unsigned := 68;
-   Dev_Attr_Max_Texture1_DLinear_Width                   : constant Interfaces.C.unsigned := 69;
-   Dev_Attr_Max_Texture2_DLinear_Width                   : constant Interfaces.C.unsigned := 70;
-   Dev_Attr_Max_Texture2_DLinear_Height                  : constant Interfaces.C.unsigned := 71;
-   Dev_Attr_Max_Texture2_DLinear_Pitch                   : constant Interfaces.C.unsigned := 72;
-   Dev_Attr_Max_Texture2_DMipmapped_Width                : constant Interfaces.C.unsigned := 73;
-   Dev_Attr_Max_Texture2_DMipmapped_Height               : constant Interfaces.C.unsigned := 74;
-   Dev_Attr_Compute_Capability_Major                     : constant Interfaces.C.unsigned := 75;
-   Dev_Attr_Compute_Capability_Minor                     : constant Interfaces.C.unsigned := 76;
-   Dev_Attr_Max_Texture1_DMipmapped_Width                : constant Interfaces.C.unsigned := 77;
-   Dev_Attr_Stream_Priorities_Supported                  : constant Interfaces.C.unsigned := 78;
-   Dev_Attr_Global_L1_Cache_Supported                    : constant Interfaces.C.unsigned := 79;
-   Dev_Attr_Local_L1_Cache_Supported                     : constant Interfaces.C.unsigned := 80;
-   Dev_Attr_Max_Shared_Memory_Per_Multiprocessor         : constant Interfaces.C.unsigned := 81;
-   Dev_Attr_Max_Registers_Per_Multiprocessor             : constant Interfaces.C.unsigned := 82;
-   Dev_Attr_Managed_Memory                               : constant Interfaces.C.unsigned := 83;
-   Dev_Attr_Is_Multi_Gpu_Board                           : constant Interfaces.C.unsigned := 84;
-   Dev_Attr_Multi_Gpu_Board_Group_ID                     : constant Interfaces.C.unsigned := 85;
-   Dev_Attr_Host_Native_Atomic_Supported                 : constant Interfaces.C.unsigned := 86;
-   Dev_Attr_Single_To_Double_Precision_Perf_Ratio        : constant Interfaces.C.unsigned := 87;
-   Dev_Attr_Pageable_Memory_Access                       : constant Interfaces.C.unsigned := 88;
-   Dev_Attr_Concurrent_Managed_Access                    : constant Interfaces.C.unsigned := 89;
-   Dev_Attr_Compute_Preemption_Supported                 : constant Interfaces.C.unsigned := 90;
-   Dev_Attr_Can_Use_Host_Pointer_For_Registered_Mem      : constant Interfaces.C.unsigned := 91;
-   Dev_Attr_Reserved92                                   : constant Interfaces.C.unsigned := 92;
-   Dev_Attr_Reserved93                                   : constant Interfaces.C.unsigned := 93;
-   Dev_Attr_Reserved94                                   : constant Interfaces.C.unsigned := 94;
-   Dev_Attr_Cooperative_Launch                           : constant Interfaces.C.unsigned := 95;
-   Dev_Attr_Cooperative_Multi_Device_Launch              : constant Interfaces.C.unsigned := 96;
-   Dev_Attr_Max_Shared_Memory_Per_Block_Optin            : constant Interfaces.C.unsigned := 97;
-   Dev_Attr_Can_Flush_Remote_Writes                      : constant Interfaces.C.unsigned := 98;
-   Dev_Attr_Host_Register_Supported                      : constant Interfaces.C.unsigned := 99;
-   Dev_Attr_Pageable_Memory_Access_Uses_Host_Page_Tables : constant Interfaces.C.unsigned := 100;
-   Dev_Attr_Direct_Managed_Mem_Access_From_Host          : constant Interfaces.C.unsigned := 101;
-   subtype Device_P2_PAttr is Interfaces.C.unsigned;
-   Dev_P2_PAttr_Performance_Rank            : constant Interfaces.C.unsigned := 1;
-   Dev_P2_PAttr_Access_Supported            : constant Interfaces.C.unsigned := 2;
-   Dev_P2_PAttr_Native_Atomic_Supported     : constant Interfaces.C.unsigned := 3;
-   Dev_P2_PAttr_Cuda_Array_Access_Supported : constant Interfaces.C.unsigned := 4;
-   subtype Anon1005_Bytes_Array is Interfaces.C.char_array (0 .. 15);
->>>>>>> temporary_branch
 
    type CUuuid_St is record
       Bytes : Anon1005_Array1007;
    end record;
    subtype CUuuid is CUuuid_St;
    subtype UUID_T is CUuuid_St;
-<<<<<<< HEAD
    subtype Anon1010_Array1012 is Interfaces.C.char_array (0 .. 255);
    subtype Anon1010_Array1014 is Interfaces.C.char_array (0 .. 7);
 
@@ -844,123 +612,6 @@ package CUDA.Driver_Types is
       Direct_Managed_Mem_Access_From_Host          : int;
    end record;
    subtype Anon1019_Array1021 is Interfaces.C.char_array (0 .. 63);
-=======
-   subtype Anon1010_Name_Array is Interfaces.C.char_array (0 .. 255);
-   subtype Anon1010_Luid_Array is Interfaces.C.char_array (0 .. 7);
-
-   type Anon1010_Max_Threads_Dim_Array is array (0 .. 2) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Grid_Size_Array is array (0 .. 2) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture2_D_Array is array (0 .. 1) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture2_DMipmap_Array is array (0 .. 1) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture2_DLinear_Array is array (0 .. 2) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture2_DGather_Array is array (0 .. 1) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture3_D_Array is array (0 .. 2) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture3_DAlt_Array is array (0 .. 2) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture1_DLayered_Array is array (0 .. 1) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture2_DLayered_Array is array (0 .. 2) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Texture_Cubemap_Layered_Array is array (0 .. 1) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Surface2_D_Array is array (0 .. 1) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Surface3_D_Array is array (0 .. 2) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Surface1_DLayered_Array is array (0 .. 1) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Surface2_DLayered_Array is array (0 .. 2) of aliased Interfaces.C.int;
-
-   type Anon1010_Max_Surface_Cubemap_Layered_Array is array (0 .. 1) of aliased Interfaces.C.int;
-
-   type Device_Prop is record
-      Name                                         : aliased Anon1010_Name_Array;
-      Uuid                                         : aliased UUID_T;
-      Luid                                         : aliased Anon1010_Luid_Array;
-      Luid_Device_Node_Mask                        : aliased Interfaces.C.unsigned;
-      Total_Global_Mem                             : aliased CUDA.Crtdefs.Size_T;
-      Shared_Mem_Per_Block                         : aliased CUDA.Crtdefs.Size_T;
-      Regs_Per_Block                               : aliased Interfaces.C.int;
-      Warp_Size                                    : aliased Interfaces.C.int;
-      Mem_Pitch                                    : aliased CUDA.Crtdefs.Size_T;
-      Max_Threads_Per_Block                        : aliased Interfaces.C.int;
-      Max_Threads_Dim                              : aliased Anon1010_Max_Threads_Dim_Array;
-      Max_Grid_Size                                : aliased Anon1010_Max_Grid_Size_Array;
-      Clock_Rate                                   : aliased Interfaces.C.int;
-      Total_Const_Mem                              : aliased CUDA.Crtdefs.Size_T;
-      Major                                        : aliased Interfaces.C.int;
-      Minor                                        : aliased Interfaces.C.int;
-      Texture_Alignment                            : aliased CUDA.Crtdefs.Size_T;
-      Texture_Pitch_Alignment                      : aliased CUDA.Crtdefs.Size_T;
-      Device_Overlap                               : aliased Interfaces.C.int;
-      Multi_Processor_Count                        : aliased Interfaces.C.int;
-      Kernel_Exec_Timeout_Enabled                  : aliased Interfaces.C.int;
-      Integrated                                   : aliased Interfaces.C.int;
-      Can_Map_Host_Memory                          : aliased Interfaces.C.int;
-      Compute_Mode                                 : aliased Interfaces.C.int;
-      Max_Texture1_D                               : aliased Interfaces.C.int;
-      Max_Texture1_DMipmap                         : aliased Interfaces.C.int;
-      Max_Texture1_DLinear                         : aliased Interfaces.C.int;
-      Max_Texture2_D                               : aliased Anon1010_Max_Texture2_D_Array;
-      Max_Texture2_DMipmap                         : aliased Anon1010_Max_Texture2_DMipmap_Array;
-      Max_Texture2_DLinear                         : aliased Anon1010_Max_Texture2_DLinear_Array;
-      Max_Texture2_DGather                         : aliased Anon1010_Max_Texture2_DGather_Array;
-      Max_Texture3_D                               : aliased Anon1010_Max_Texture3_D_Array;
-      Max_Texture3_DAlt                            : aliased Anon1010_Max_Texture3_DAlt_Array;
-      Max_Texture_Cubemap                          : aliased Interfaces.C.int;
-      Max_Texture1_DLayered                        : aliased Anon1010_Max_Texture1_DLayered_Array;
-      Max_Texture2_DLayered                        : aliased Anon1010_Max_Texture2_DLayered_Array;
-      Max_Texture_Cubemap_Layered                  : aliased Anon1010_Max_Texture_Cubemap_Layered_Array;
-      Max_Surface1_D                               : aliased Interfaces.C.int;
-      Max_Surface2_D                               : aliased Anon1010_Max_Surface2_D_Array;
-      Max_Surface3_D                               : aliased Anon1010_Max_Surface3_D_Array;
-      Max_Surface1_DLayered                        : aliased Anon1010_Max_Surface1_DLayered_Array;
-      Max_Surface2_DLayered                        : aliased Anon1010_Max_Surface2_DLayered_Array;
-      Max_Surface_Cubemap                          : aliased Interfaces.C.int;
-      Max_Surface_Cubemap_Layered                  : aliased Anon1010_Max_Surface_Cubemap_Layered_Array;
-      Surface_Alignment                            : aliased CUDA.Crtdefs.Size_T;
-      Concurrent_Kernels                           : aliased Interfaces.C.int;
-      ECCEnabled                                   : aliased Interfaces.C.int;
-      Pci_Bus_ID                                   : aliased Interfaces.C.int;
-      Pci_Device_ID                                : aliased Interfaces.C.int;
-      Pci_Domain_ID                                : aliased Interfaces.C.int;
-      Tcc_Driver                                   : aliased Interfaces.C.int;
-      Async_Engine_Count                           : aliased Interfaces.C.int;
-      Unified_Addressing                           : aliased Interfaces.C.int;
-      Memory_Clock_Rate                            : aliased Interfaces.C.int;
-      Memory_Bus_Width                             : aliased Interfaces.C.int;
-      L2_Cache_Size                                : aliased Interfaces.C.int;
-      Max_Threads_Per_Multi_Processor              : aliased Interfaces.C.int;
-      Stream_Priorities_Supported                  : aliased Interfaces.C.int;
-      Global_L1_Cache_Supported                    : aliased Interfaces.C.int;
-      Local_L1_Cache_Supported                     : aliased Interfaces.C.int;
-      Shared_Mem_Per_Multiprocessor                : aliased CUDA.Crtdefs.Size_T;
-      Regs_Per_Multiprocessor                      : aliased Interfaces.C.int;
-      Managed_Memory                               : aliased Interfaces.C.int;
-      Is_Multi_Gpu_Board                           : aliased Interfaces.C.int;
-      Multi_Gpu_Board_Group_ID                     : aliased Interfaces.C.int;
-      Host_Native_Atomic_Supported                 : aliased Interfaces.C.int;
-      Single_To_Double_Precision_Perf_Ratio        : aliased Interfaces.C.int;
-      Pageable_Memory_Access                       : aliased Interfaces.C.int;
-      Concurrent_Managed_Access                    : aliased Interfaces.C.int;
-      Compute_Preemption_Supported                 : aliased Interfaces.C.int;
-      Can_Use_Host_Pointer_For_Registered_Mem      : aliased Interfaces.C.int;
-      Cooperative_Launch                           : aliased Interfaces.C.int;
-      Cooperative_Multi_Device_Launch              : aliased Interfaces.C.int;
-      Shared_Mem_Per_Block_Optin                   : aliased CUDA.Crtdefs.Size_T;
-      Pageable_Memory_Access_Uses_Host_Page_Tables : aliased Interfaces.C.int;
-      Direct_Managed_Mem_Access_From_Host          : aliased Interfaces.C.int;
-   end record with
-      Convention => C_Pass_By_Copy;
-   subtype Anon1019_Reserved_Array is Interfaces.C.char_array (0 .. 63);
->>>>>>> temporary_branch
 
    type Ipc_Event_Handle_St is record
       Reserved : Anon1019_Array1021;
@@ -972,7 +623,6 @@ package CUDA.Driver_Types is
       Reserved : Anon1023_Array1021;
    end record;
    subtype Ipc_Mem_Handle_T is Ipc_Mem_Handle_St;
-<<<<<<< HEAD
    subtype External_Memory_Handle_Type is unsigned;
    External_Memory_Handle_Type_Opaque_Fd           : unsigned;
    External_Memory_Handle_Type_Opaque_Win32        : unsigned;
@@ -987,28 +637,6 @@ package CUDA.Driver_Types is
       Handle : System.Address;
       Name   : System.Address;
    end record;
-=======
-   subtype External_Memory_Handle_Type is Interfaces.C.unsigned;
-   External_Memory_Handle_Type_Opaque_Fd           : constant Interfaces.C.unsigned := 1;
-   External_Memory_Handle_Type_Opaque_Win32        : constant Interfaces.C.unsigned := 2;
-   External_Memory_Handle_Type_Opaque_Win32_Kmt    : constant Interfaces.C.unsigned := 3;
-   External_Memory_Handle_Type_D3_D12_Heap         : constant Interfaces.C.unsigned := 4;
-   External_Memory_Handle_Type_D3_D12_Resource     : constant Interfaces.C.unsigned := 5;
-   External_Memory_Handle_Type_D3_D11_Resource     : constant Interfaces.C.unsigned := 6;
-   External_Memory_Handle_Type_D3_D11_Resource_Kmt : constant Interfaces.C.unsigned := 7;
-   External_Memory_Handle_Type_Nv_Sci_Buf          : constant Interfaces.C.unsigned := 8;
-
-   type Anon1026_Win32_Struct is record
-      Handle : System.Address;
-      Name   : System.Address;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon1026_Handle_Union (discr : Interfaces.C.unsigned := 0) is record
-      case discr is
-         when 0 =>
-            Fd : aliased Interfaces.C.int;
->>>>>>> temporary_branch
 
    type Anon1026_Union1027 is record
       Fd                : int;
@@ -1017,7 +645,6 @@ package CUDA.Driver_Types is
    end record;
 
    type External_Memory_Handle_Desc is record
-<<<<<<< HEAD
       C_Type : External_Memory_Handle_Type;
       Handle : Anon1026_Union1027;
       Size   : Extensions.unsigned_long_long;
@@ -1051,53 +678,6 @@ package CUDA.Driver_Types is
       Handle : System.Address;
       Name   : System.Address;
    end record;
-=======
-      C_Type : aliased External_Memory_Handle_Type;
-      Handle : aliased Anon1026_Handle_Union;
-      Size   : aliased Interfaces.C.Extensions.unsigned_long_long;
-      Flags  : aliased Interfaces.C.unsigned;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type External_Memory_Buffer_Desc is record
-      Offset : aliased Interfaces.C.Extensions.unsigned_long_long;
-      Size   : aliased Interfaces.C.Extensions.unsigned_long_long;
-      Flags  : aliased Interfaces.C.unsigned;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type External_Memory_Mipmapped_Array_Desc is record
-      Offset      : aliased Interfaces.C.Extensions.unsigned_long_long;
-      Format_Desc : aliased Channel_Format_Desc;
-      Extent      : aliased Extent_T;
-      Flags       : aliased Interfaces.C.unsigned;
-      Num_Levels  : aliased Interfaces.C.unsigned;
-   end record with
-      Convention => C_Pass_By_Copy;
-   subtype External_Semaphore_Handle_Type is Interfaces.C.unsigned;
-   External_Semaphore_Handle_Type_Opaque_Fd        : constant Interfaces.C.unsigned := 1;
-   External_Semaphore_Handle_Type_Opaque_Win32     : constant Interfaces.C.unsigned := 2;
-   External_Semaphore_Handle_Type_Opaque_Win32_Kmt : constant Interfaces.C.unsigned := 3;
-   External_Semaphore_Handle_Type_D3_D12_Fence     : constant Interfaces.C.unsigned := 4;
-   External_Semaphore_Handle_Type_D3_D11_Fence     : constant Interfaces.C.unsigned := 5;
-   External_Semaphore_Handle_Type_Nv_Sci_Sync      : constant Interfaces.C.unsigned := 6;
-   External_Semaphore_Handle_Type_Keyed_Mutex      : constant Interfaces.C.unsigned := 7;
-   External_Semaphore_Handle_Type_Keyed_Mutex_Kmt  : constant Interfaces.C.unsigned := 8;
-
-   type Anon1032_Win32_Struct is record
-      Handle : System.Address;
-      Name   : System.Address;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon1032_Handle_Union (discr : Interfaces.C.unsigned := 0) is record
-      case discr is
-         when 0 =>
-            Fd : aliased Interfaces.C.int;
-
-         when 1 =>
-            Win32 : aliased Anon1032_Win32_Struct;
->>>>>>> temporary_branch
 
    type Anon1032_Union1033 is record
       Fd              : int;
@@ -1106,7 +686,6 @@ package CUDA.Driver_Types is
    end record;
 
    type External_Semaphore_Handle_Desc is record
-<<<<<<< HEAD
       C_Type : External_Semaphore_Handle_Type;
       Handle : Anon1032_Union1033;
       Flags  : unsigned;
@@ -1160,84 +739,6 @@ package CUDA.Driver_Types is
       Params : Anon1040_Struct1041;
       Flags  : unsigned;
    end record;
-=======
-      C_Type : aliased External_Semaphore_Handle_Type;
-      Handle : aliased Anon1032_Handle_Union;
-      Flags  : aliased Interfaces.C.unsigned;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon1035_Fence_Struct is record
-      Value : aliased Interfaces.C.Extensions.unsigned_long_long;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon1035_Nv_Sci_Sync_Union (discr : Interfaces.C.unsigned := 0) is record
-      case discr is
-         when 0 =>
-            Fence : System.Address;
-
-         when others =>
-            Reserved : aliased Interfaces.C.Extensions.unsigned_long_long;
-      end case;
-   end record with
-      Convention      => C_Pass_By_Copy,
-      Unchecked_Union => True;
-
-   type Anon1035_Keyed_Mutex_Struct is record
-      Key : aliased Interfaces.C.Extensions.unsigned_long_long;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon1035_Params_Struct is record
-      Fence       : aliased Anon1035_Fence_Struct;
-      Nv_Sci_Sync : aliased Anon1035_Nv_Sci_Sync_Union;
-      Keyed_Mutex : aliased Anon1035_Keyed_Mutex_Struct;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type External_Semaphore_Signal_Params is record
-      Params : aliased Anon1035_Params_Struct;
-      Flags  : aliased Interfaces.C.unsigned;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon1040_Fence_Struct is record
-      Value : aliased Interfaces.C.Extensions.unsigned_long_long;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon1040_Nv_Sci_Sync_Union (discr : Interfaces.C.unsigned := 0) is record
-      case discr is
-         when 0 =>
-            Fence : System.Address;
-
-         when others =>
-            Reserved : aliased Interfaces.C.Extensions.unsigned_long_long;
-      end case;
-   end record with
-      Convention      => C_Pass_By_Copy,
-      Unchecked_Union => True;
-
-   type Anon1040_Keyed_Mutex_Struct is record
-      Key        : aliased Interfaces.C.Extensions.unsigned_long_long;
-      Timeout_Ms : aliased Interfaces.C.unsigned;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type Anon1040_Params_Struct is record
-      Fence       : aliased Anon1040_Fence_Struct;
-      Nv_Sci_Sync : aliased Anon1040_Nv_Sci_Sync_Union;
-      Keyed_Mutex : aliased Anon1040_Keyed_Mutex_Struct;
-   end record with
-      Convention => C_Pass_By_Copy;
-
-   type External_Semaphore_Wait_Params is record
-      Params : aliased Anon1040_Params_Struct;
-      Flags  : aliased Interfaces.C.unsigned;
-   end record with
-      Convention => C_Pass_By_Copy;
->>>>>>> temporary_branch
    subtype Error_T is Error;
 
    type CUstream_St is null record;
@@ -1280,15 +781,9 @@ package CUDA.Driver_Types is
 
    type Kernel_Node_Params is record
       Func             : System.Address;
-<<<<<<< HEAD
       Grid_Dim         : CUDA.Vector_Types.Dim3;
       Block_Dim        : CUDA.Vector_Types.Dim3;
       Shared_Mem_Bytes : unsigned;
-=======
-      Grid_Dim         : aliased CUDA.Vector_Types.Dim3;
-      Block_Dim        : aliased CUDA.Vector_Types.Dim3;
-      Shared_Mem_Bytes : aliased Interfaces.C.unsigned;
->>>>>>> temporary_branch
       Kernel_Params    : System.Address;
       Extra            : System.Address;
    end record;

--- a/api/cuda_api/cuda-runtime_api.adb
+++ b/api/cuda_api/cuda-runtime_api.adb
@@ -2,20 +2,20 @@ with cuda_runtime_api_h; use cuda_runtime_api_h;
 
 package body CUDA.Runtime_Api is
 
-   overriding procedure Allocate (Self : in out CUDA_Device_Pool; Addr : out System.Address; Size : System.Storage_Elements.Storage_Count; Alignment : System.Storage_Elements.Storage_Count) is
-   begin
-      Addr := Malloc (CUDA.Crtdefs.Size_T (Size));
-   end Allocate;
+   --  overriding procedure Allocate (Self : in out CUDA_Device_Pool; Addr : out System.Address; Size : System.Storage_Elements.Storage_Count; Alignment : System.Storage_Elements.Storage_Count) is
+   --  begin
+   --     Addr := Malloc (CUDA.Crtdefs.Size_T (Size));
+   --  end Allocate;
 
    --  overriding procedure Copy_To_Pool (Self : in out CUDA_Device_Pool; Addr : System.Address; Value : aliased System.Storage_Elements.Storage_Array; Size : System.Storage_Elements.Storage_Count) is
    --  begin
    --     Memcpy (Addr, Value'Address, CUDA.Crtdefs.Size_T (Size), CUDA.Driver_Types.Memcpy_Host_To_Device);
    --  end Copy_To_Pool;
 
-   overriding procedure Deallocate (Self : in out CUDA_Device_Pool; Addr : System.Address; Size : System.Storage_Elements.Storage_Count; Alignment : System.Storage_Elements.Storage_Count) is
-   begin
-      Free (Addr);
-   end Deallocate;
+   --  overriding procedure Deallocate (Self : in out CUDA_Device_Pool; Addr : System.Address; Size : System.Storage_Elements.Storage_Count; Alignment : System.Storage_Elements.Storage_Count) is
+   --  begin
+   --     Free (Addr);
+   --  end Deallocate;
 
    procedure Device_Reset is
    begin

--- a/api/cuda_api/cuda-runtime_api.ads
+++ b/api/cuda_api/cuda-runtime_api.ads
@@ -16,13 +16,13 @@ with Ada.Exceptions;
 with CUDA;
 
 package CUDA.Runtime_Api is
-   type CUDA_Device_Pool is new System.Storage_Pools.Root_Storage_Pool with null record;
-   overriding procedure Allocate (Self : in out CUDA_Device_Pool; Addr : out System.Address; Size : System.Storage_Elements.Storage_Count; Alignment : System.Storage_Elements.Storage_Count);
+   --  type CUDA_Device_Pool is new System.Storage_Pools.Root_Storage_Pool with null record;
+   --  overriding procedure Allocate (Self : in out CUDA_Device_Pool; Addr : out System.Address; Size : System.Storage_Elements.Storage_Count; Alignment : System.Storage_Elements.Storage_Count);
    --  overriding procedure Copy_To_Pool (Self : in out CUDA_Device_Pool; Addr : System.Address; Value : aliased System.Storage_Elements.Storage_Array; Size : System.Storage_Elements.Storage_Count);
-   overriding procedure Deallocate (Self : in out CUDA_Device_Pool; Addr : System.Address; Size : System.Storage_Elements.Storage_Count; Alignment : System.Storage_Elements.Storage_Count);
-   overriding function Storage_Size (Self : CUDA_Device_Pool) return System.Storage_Elements.Storage_Count is (System.Storage_Elements.Storage_Count'Last) with
-      Inline => True;
-   CUDA_Device : CUDA_Device_Pool;
+   --  overriding procedure Deallocate (Self : in out CUDA_Device_Pool; Addr : System.Address; Size : System.Storage_Elements.Storage_Count; Alignment : System.Storage_Elements.Storage_Count);
+   --  overriding function Storage_Size (Self : CUDA_Device_Pool) return System.Storage_Elements.Storage_Count is (System.Storage_Elements.Storage_Count'Last) with
+      --  Inline => True;
+   --  CUDA_Device : CUDA_Device_Pool;
    CUDART_VERSION : constant := 10_020;
    procedure Device_Reset;
    procedure Device_Synchronize;

--- a/examples/0_Simple/vectorAdd/src/kernel.ads
+++ b/examples/0_Simple/vectorAdd/src/kernel.ads
@@ -1,5 +1,4 @@
 with System;
-with CUDA.Runtime_Api;  use CUDA.Runtime_Api;
 
 with Interfaces; use Interfaces;
 with Interfaces.C;            use Interfaces.C;

--- a/examples/0_Simple/vectorAdd/src/main.adb
+++ b/examples/0_Simple/vectorAdd/src/main.adb
@@ -12,7 +12,7 @@ with System.Storage_Elements;
 with CUDA.Runtime_Api;  use CUDA.Runtime_Api;
 with CUDA.Driver_Types; use CUDA.Driver_Types;
 with CUDA.Vector_Types;
-with CUDA.Crtdefs;
+with CUDA.Corecrt;
 
 with Kernel; use Kernel;
 
@@ -22,7 +22,10 @@ procedure Main is
 
    H_A, H_B, H_C : Access_Host_Float_Array;
    D_A, D_B, D_C : System.Address;
-   Array_Size : CUDA.Crtdefs.Size_T := CUDA.Crtdefs.Size_T(Interfaces.C.c_float'size * Num_Elements / 8);
+   pragma Warnings (Off, D_A);
+   pragma Warnings (Off, D_B);
+   pragma Warnings (Off, D_C);
+   Array_Size : CUDA.Corecrt.Size_T := CUDA.Corecrt.Size_T(Interfaces.C.c_float'size * Num_Elements / 8);
 
    Threads_Per_Block : Integer := 256;
    Blocks_Per_Grid : Integer :=
@@ -52,9 +55,9 @@ begin
    H_A.all := (others => Float (Random (Gen)));
    H_B.all := (others => Float (Random (Gen)));
 
-   D_A := Cuda.Runtime_Api.Malloc (Array_Size);
-   D_B := Cuda.Runtime_Api.Malloc (Array_Size);
-   D_C := Cuda.Runtime_Api.Malloc (Array_Size);
+   Cuda.Runtime_Api.Malloc (D_A'Address, Array_Size);
+   Cuda.Runtime_Api.Malloc (D_B'Address, Array_Size);
+   Cuda.Runtime_Api.Malloc (D_C'Address, Array_Size);
 
    Cuda.Runtime_Api.Memcpy
      (Dst   => D_A,
@@ -71,7 +74,7 @@ begin
    Put_Line ("CUDA kernel launch with " & blocks_Per_Grid'Img &
                " blocks of " & Threads_Per_Block'Img & "  threads");
 
-   pragma CUDA_Execute (Vector_Add (D_A, D_B, D_C, Num_Elements), Blocks, Grids);
+   pragma CUDA_Execute (Vector_Add (D_A, D_B, D_C, Num_Elements), Grids, Blocks);
 
    Err := Get_Last_Error;
 


### PR DESCRIPTION
The vectorAdd example can be compiled again but now an
"INVALIDCONFIGURATIONERROR" is thrown when attempting to launch the
kernel.

Getting to this state required several changes:
- Re-creating the cuda-crtdefs.ads file and making it rename the crtcore
  package. Doing this was required as the compiler needs to find the types that
  used to be in crtdefs to generate kernels. Ultimately the compiler will look
  for the types in the right place, but this was a quick and dirty way to go
  back to a working state.
- Removing git conflict markers in cuda-driver_types.ads.
- Commenting out the storage pools. They aren't actually implemented nor used
  yet so this was the simplest workaround for the warnings they generated.
- Removing the `with CUDA.Runtime_API` clause in kernel.ads..This was
  apparently not needed anymore and resulted in warnings.
- Adapting to the new Malloc calls, which require passing an address as
  receiving parameter. This resulted in warnings being displayed about
  D_A, D_B and D_C being read without being initialized. The warnings
  are silenced for now but Malloc's parameter should probably be marked
  in/out.

@QuentinOchem I'm still trying to figure out why the INVALIDCONFIGURATIONERROR
is thrown. Could you take a look at this PR and see if I've done anything
obviously wrong with the bindings?