### PR TITLE
Update CUDA runtime definition to be based on new "None" profile

### DIFF
--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -33,10 +33,12 @@ class CUDADevice(DFBBTarget):
         # The required compiler switches
         return ('-gnatp',)
 
+    def base_profile(self, profile):
+        # No base profile as the CUDA runtime uses it's own sources.
+        return 'none'
+
     def amend_rts(self, rts_profile, cfg):
-        # For simplicity pretend to be ZFP. CUDA rts_sources doesn't use any
-        # ZFP RTS variables so we are safe to do this for now.
-        super(CUDADevice, self).amend_rts('zfp', cfg)
+        super(CUDADevice, self).amend_rts('none', cfg)
         cfg.rts_vars['Cuda_Target'] = 'device'
         # Add cuda sources. Probably better to put these in their own cuda
         # directory with their own make file.

--- a/runtime/cuda_sources.py
+++ b/runtime/cuda_sources.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2018, AdaCore
+# Copyright (C) 2016-2021, AdaCore
 #
 # Python script to gather files for the bareboard runtime.
 # Don't use any fancy features.  Ideally, this script should work with any
@@ -8,7 +8,7 @@
 
 
 #
-# Copyright (C) 2016-2018, AdaCore
+# Copyright (C) 2016-2021, AdaCore
 #
 # This file holds the source list and scenario variables of the runtimes
 
@@ -21,7 +21,7 @@
 
 # default value is always the first value of the list. So for example for
 # optional features enabled via a "no" or "yes" value, always set 'no' as the
-# first option to disable the feature by default (zfp and ravenscar-sfp cases).
+# first option to disable the feature by default.
 
 rts_scenarios = {
     'Cuda_Target': ['device', 'host'],
@@ -45,12 +45,12 @@ rts_scenarios = {
 # * a condition takes the forms:
 #     Scenario_Var_Name:accepted_values
 #   with accepted_values being:
-#     a) a simple value (e.g. RTS_Profile:zfp): evaluated to True if
-#        RTS_Profile is set to "zfp"
-#     b) a coma-separated list of values (e.g. RTS_Profile:zfp,ravenscar-sfp):
-#        evaluated to True if RTS_Profile is "zfp" or "ravenscar-sfp"
+#     a) a simple value (e.g. RTS_Profile:light): evaluated to True if
+#        RTS_Profile is set to "light"
+#     b) a coma-separated list of values (e.g. RTS_Profile:light,light-tasking):
+#        evaluated to True if RTS_Profile is "light" or "light-tasking"
 #     c) a negated value, preceded with an exclamation point (e.g.
-#        RTS_Profile:!zfp): evaluated to True if RTS_Profile is not "zfp".
+#        RTS_Profile:!light): evaluated to True if RTS_Profile is not "light".
 # If no condition is defined, then the folder is always used.
 rts_sources = {
     # LIBGNAT


### PR DESCRIPTION
The transition of the ZFP runtime to the new Light runtime means the
"cuda-device" runtime can't piggyback off a predefined runtime anymore.
Consequently, a new "None" profile has been introduced in bb-runtimes to
support special runtimes like cuda that aren't based on an existing runtime.

TN: U913-011