### PR TITLE
s-stoele.adb: remove compiler_unit_warning pragma

### DIFF
--- a/runtime/device_gnat/s-stoele.adb
+++ b/runtime/device_gnat/s-stoele.adb
@@ -31,8 +31,6 @@
 
 --  This is the CUDA version. It omits constraint checks.
 
-pragma Compiler_Unit_Warning;
-
 with Ada.Unchecked_Conversion;
 
 package body System.Storage_Elements is


### PR DESCRIPTION
This pragma has been removed from recent GNAT versions.
