### PR TITLE
V120-001: make wrapper version pluggable

### DIFF
--- a/wrapper/src/gnatcuda_wrapper.adb
+++ b/wrapper/src/gnatcuda_wrapper.adb
@@ -2,11 +2,11 @@
 --                                                                          --
 --                         GNAT COMPILER COMPONENTS                         --
 --                                                                          --
---                       G N A T C C G _ W R A P P E R                      --
+--                     G N A T C U D A _ W R A P P E R                      --
 --                                                                          --
 --                                 B o d y                                  --
 --                                                                          --
---          Copyright (C) 2010-2020, Free Software Foundation, Inc.         --
+--          Copyright (C) 2010-2022, Free Software Foundation, Inc.         --
 --                                                                          --
 -- GNAT is free software;  you can  redistribute it  and/or modify it under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -30,6 +30,8 @@ with GNAT.Case_Util;            use GNAT.Case_Util;
 with GNAT.Directory_Operations; use GNAT.Directory_Operations;
 with GNAT.IO;                   use GNAT.IO;
 with GNAT.OS_Lib;               use GNAT.OS_Lib;
+
+with Gnatvsn;
 
 --  Wrapper around <install>/libexec/gnat_ccg/bin/c-xxx to be
 --  installed under <install>/bin
@@ -226,7 +228,11 @@ begin
          elsif Arg = "-v" then
             Put_Line ("Target: cuda");
             --  ??? temporary hard coded version numbers
-            Put_Line ("cuda-gcc version 22.0 (for GNAT Pro 22.0w (20210315))");
+            Put_Line ("cuda-gcc version "
+              & gnatvsn.Library_Version
+              & " (for GNAT Pro "
+              & gnatvsn.Gnat_Static_Version_String
+              & ")");
 
             Verbose := True;
             LLVM_Arg_Number := @ + 1;

--- a/wrapper/src/gnatvsn.ads
+++ b/wrapper/src/gnatvsn.ads
@@ -1,0 +1,37 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                              G N A T V S N                               --
+--                                                                          --
+--                                 S p e c                                  --
+--                                                                          --
+--          Copyright (C) 1992-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
+-- for  more details.  You should have  received  a copy of the GNU General --
+-- Public License  distributed with GNAT; see file COPYING3.  If not, go to --
+-- http://www.gnu.org/licenses for a complete copy of the license.          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  This package spec holds version information for the GNAT tools.
+--  It is updated whenever the release number is changed.
+
+package Gnatvsn is
+
+   Gnat_Static_Version_String : constant String := "23.0w (19940713)";
+
+   Library_Version : constant String := "23";
+
+   Current_Year : constant String := "2022";
+
+end Gnatvsn;


### PR DESCRIPTION
Gnatvsn.ads is edited by nightly scripts to get a date and version that
match GNAT's values.
