### PR TITLE
GNATCuda: Automatic binding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ main: install/bin libdevice.ads
 	cp wrapper/obj/gnatcuda_wrapper install/bin/cuda-gcc
 	cp install/bin/cuda-gcc $(llvm_dir)/bin/cuda-gcc
 	./gen-rts-sources.py --bb-dir $(BB_SRC) --gnat $(GNAT_SRC) --rts-profile=light
-	./build-rts.py --bb-dir $(BB_SRC) --rts-src-descriptor install/lib/gnat/rts-sources.json cuda-device --force -b
+	# Disable bindings because cuda_env is not installed at this point
+	CUDA_GCC_DISABLE_BINDINGS=1 ./build-rts.py --bb-dir $(BB_SRC) --rts-src-descriptor install/lib/gnat/rts-sources.json cuda-device --force -b
 	mv install/device-cuda install/lib/rts-device-cuda
 	cp -R runtime/device_gnat/* install/lib/rts-device-cuda/gnat/
 	rm -rf $(llvm_dir)/lib/rts-device-cuda

--- a/wrapper/src/cuda_bindings.adb
+++ b/wrapper/src/cuda_bindings.adb
@@ -89,23 +89,20 @@ package body CUDA_Bindings is
 
    function Up_To_Date return Boolean is (Version_Info_Equals (Version_Info));
 
-   function Getenv_Safe (Name : String; Default : String) return String is
+   function Getenv_Safe (Name : String) return String is
       -- Memory-safe getenv
       S_Acc : GNAT.OS_Lib.String_Access := GNAT.OS_Lib.Getenv (Name);
+      S : String := S_Acc.all;
    begin
-      if S_Acc /= null then
-         return S : String := S_Acc.all do
-            GNAT.OS_Lib.Free (S_Acc);
-         end return;
-      else
-         return Default;
-      end if;
+      GNAT.OS_Lib.Free (S_Acc);
+      return S;
    end Getenv_Safe;
+   Getenv_Null : constant String := "";
 
    procedure Generate is
       Version : String := Version_Info;
    begin
-      if Getenv_Safe ("CUDA_ROOT", "") = "" then
+      if Getenv_Safe ("CUDA_ROOT") = Getenv_Null then
          GNAT.Os_Lib.Setenv ("CUDA_ROOT", Default_CUDA_Root);
       end if;
 

--- a/wrapper/src/cuda_bindings.adb
+++ b/wrapper/src/cuda_bindings.adb
@@ -109,6 +109,11 @@ package body CUDA_Bindings is
          GNAT.Os_Lib.Setenv ("CUDA_ROOT", Default_CUDA_Root);
       end if;
 
+      --  Sanity check that we're installed
+      pragma Assert
+        (Directory.Is_Directory,
+         "directory " & (+Directory) & " doesn't exist: are we installed?");
+
       pragma Assert
         (Shell
            (GNAT.Os_Lib.Getenv ("SHELL").all & " bind.sh", CWD => Directory) =

--- a/wrapper/src/cuda_bindings.adb
+++ b/wrapper/src/cuda_bindings.adb
@@ -1,0 +1,119 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                         C U D A   B I N D I N G S                        --
+--                                                                          --
+--                                 B o d y                                  --
+--                                                                          --
+--          Copyright (C) 2010-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
+-- for  more details.  You should have  received  a copy of the GNU General --
+-- Public License  distributed with GNAT; see file COPYING3.  If not, go to --
+-- http://www.gnu.org/licenses for a complete copy of the license.          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with GNAT.OS_Lib;
+use type GNAT.OS_Lib.String_Access;
+with GNATVSN;
+with Ada.Strings.Unbounded;
+with Subprocess;  use Subprocess;
+with Ada.Text_IO; use Ada.Text_IO;
+
+package body CUDA_Bindings is
+
+   Default_CUDA_Root : constant String := "/usr/local/cuda";
+   --  !!! default not portable to Windows
+
+   function Version_Info return String is (GNATVSN.Gnat_Static_Version_String);
+
+   function Version_Info_Equals (Other : String) return Boolean is
+      F     : Ada.Text_IO.File_Type;
+      Equal : Boolean;
+   begin
+      if not Version_File.Is_Regular_File then
+         return False;
+      end if;
+
+      Open (F, In_File, Name => +Version_File);
+
+      if Other'Length = 0 then
+         -- Empty file matches the empty string
+         Equal := End_Of_File (F);
+      else
+         Equal := not End_Of_File (F);
+
+         declare
+            J : Natural := Other'First;
+            C : Character;
+         begin
+            while Equal and not End_Of_File (F) loop
+               if J > Other'Last then
+                  -- maybe too large
+                  Equal := End_Of_File (F);
+               elsif End_Of_File (F) then
+                  -- too short
+                  Equal := False;
+               else
+                  Get_Immediate (F, C);
+                  Equal := C = Other (J);
+               end if;
+
+               J := J + 1;
+            end loop;
+         end;
+      end if;
+
+      Close (F);
+
+      return Equal;
+   end Version_Info_Equals;
+
+   procedure Write_Version_Info (Version : String) is
+      F : Ada.Text_IO.File_Type;
+   begin
+      Create (F, Out_File, +Version_File);
+      Put (F, Version);
+      Close (F);
+   end Write_Version_Info;
+
+   function Up_To_Date return Boolean is (Version_Info_Equals (Version_Info));
+
+   function Getenv_Safe (Name : String; Default : String) return String is
+      -- Memory-safe getenv
+      S_Acc : GNAT.OS_Lib.String_Access := GNAT.OS_Lib.Getenv (Name);
+   begin
+      if S_Acc /= null then
+         return S : String := S_Acc.all do
+            GNAT.OS_Lib.Free (S_Acc);
+         end return;
+      else
+         return Default;
+      end if;
+   end Getenv_Safe;
+
+   procedure Generate is
+      Version : String := Version_Info;
+   begin
+      if Getenv_Safe ("CUDA_ROOT", "") = "" then
+         GNAT.Os_Lib.Setenv ("CUDA_ROOT", Default_CUDA_Root);
+      end if;
+
+      pragma Assert
+        (Shell
+           (GNAT.Os_Lib.Getenv ("SHELL").all & " bind.sh", CWD => Directory) =
+         0);
+      Write_Version_Info (Version);
+   end Generate;
+
+end CUDA_Bindings;

--- a/wrapper/src/cuda_bindings.ads
+++ b/wrapper/src/cuda_bindings.ads
@@ -1,0 +1,54 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                         C U D A   B I N D I N G S                        --
+--                                                                          --
+--                                 S p e c                                  --
+--                                                                          --
+--          Copyright (C) 2010-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
+-- for  more details.  You should have  received  a copy of the GNU General --
+-- Public License  distributed with GNAT; see file COPYING3.  If not, go to --
+-- http://www.gnu.org/licenses for a complete copy of the license.          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Paths;
+with Paths.Env;
+use all type Paths.Path;
+
+package CUDA_Bindings is
+
+   function CUDA_Install return Paths.Path
+      --  Install directory of the CUDA wrapper
+      is
+     (Paths.Env.Command_Dir.Parent) with
+      Post => CUDA_Install'Result.Is_Directory;
+      --  command is $INSTALL/bin/cuda-gcc
+
+   Directory : constant Paths.Path := CUDA_Install / "api";
+   --  Directory containing the bindings and binding infos.
+
+   Version_File : constant Paths.Path := Directory / "version";
+   --  File containing the bindings version information
+
+   function Up_To_Date return Boolean;
+   --  Returns True iff
+   --    + Bindings exist
+   --    + They are up-to-date in regard to hardware and software
+
+   procedure Generate with
+      Post => Up_To_Date;
+      --  Generate the up-to-date bindings in the directory
+
+end CUDA_Bindings;

--- a/wrapper/src/gnatcuda_wrapper.adb
+++ b/wrapper/src/gnatcuda_wrapper.adb
@@ -388,7 +388,7 @@ begin
             new String'("-o"),
             new String'(Kernel_Object));
       begin
-         Status := Spawn
+         Status := Subprocess.Spawn
            (Locate_And_Check ("llvm-gcc").all,
             Prefix_LLVM_ARGS &
               new String'("-mcpu=sm_" & GPU_Name.all) &
@@ -398,7 +398,7 @@ begin
             return Status;
          end if;
 
-         Status := Spawn
+         Status := Subprocess.Spawn
            (Locate_And_Check ("ptxas").all,
             PTXAS_Args);
 
@@ -406,7 +406,7 @@ begin
             return Status;
          end if;
 
-         Status := Spawn
+         Status := Subprocess.Spawn
            (Locate_And_Check ("fatbinary").all,
             Fatbinary_Args);
 
@@ -414,7 +414,7 @@ begin
             return Status;
          end if;
 
-         Status := Spawn (Locate_And_Check ("ld").all, Ld_Args);
+         Status := Subprocess.Spawn (Locate_And_Check ("ld").all, Ld_Args);
 
          return Status;
       end;

--- a/wrapper/src/gpr-env.adb
+++ b/wrapper/src/gpr-env.adb
@@ -1,0 +1,235 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                              G P R . E N V                               --
+--                                                                          --
+--                                 B o d y                                  --
+--                                                                          --
+--          Copyright (C) 2010-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- This library is free software;  you can redistribute it and/or modify it --
+-- under terms of the  GNU General Public License  as published by the Free --
+-- Software  Foundation;  either version 3,  or (at your  option) any later --
+-- version. This library is distributed in the hope that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE.                            --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Text_IO; use Ada.Text_IO;
+with Ada.Directories;
+
+with GNAT.Directory_Operations; use GNAT.Directory_Operations;
+with GNAT.OS_Lib; use GNAT.OS_Lib;
+
+with Paths;
+use type Paths.Path;
+
+package body GPR.Env is
+
+   Path_Separator_Str : constant String (1 .. 1) := (1 => Path_Separator);
+
+   function Test_Candidates (Path_Var : String; Name : String)
+     return Paths.Path
+     with Pre => Path_Var'Length /= 0 and Name'Length /= 0,
+          Post => Test_Candidates'Result = Paths.Null_Path
+            or (Test_Candidates'Result.Is_Regular_File
+               and Test_Candidates'Result.Is_Absolute)
+   is
+      First : Positive := Path_Var'First;
+      Last : Positive;
+   begin
+      --  Code adapted from libgpr's Find_Name_In_Path
+      while First <= Path_Var'Last loop
+         
+         while First <= Path_Var'Last
+           and then Path_Var (First) = Path_Separator
+         loop
+            First := First + 1;
+         end loop;
+
+         exit when First > Path_Var'Last;
+         
+         Last := First;
+         while Last < Path_Var'Last
+           and then Path_Var (Last) /= Path_Separator
+         loop
+            Last := Last + 1;
+         end loop;
+
+         if Path_Var (Last) = Path_Separator then
+            Last := Last - 1;
+         end if;
+         
+         declare
+            Candidate : Paths.Path
+              := Paths.Path (Path_Var (First .. Last)) / Paths.Path (Name);
+         begin
+            if Candidate.Is_Absolute then
+               if Candidate.Is_Regular_File then
+                  return Candidate;
+               end if;
+            else
+               declare
+                  Absolute_Candidate : Paths.Path
+                    := Paths.Path (Ada.Directories.Current_Directory) / Paths.Path (Candidate);
+               begin
+                  if Absolute_Candidate.Is_Regular_File then
+                     return Absolute_Candidate;
+                  end if;
+               end;
+            end if;
+         end;
+
+         First := Last + 1;
+      end loop;
+
+      return Paths.Null_Path;
+   end Test_Candidates;
+
+   function Test_Candidates (File : Ada.Text_IO.File_Type; Name : String)
+     return Paths.Path is
+     -- Splits the given opened file into lines.
+     -- If this line is the path of a directory that contains a file named Name
+     -- return the absolute path to this file.
+      Line : String (1 .. 10_000);
+      -- 10_000 is from libgpr, if it fails there, the GPR file is thus not valid ;p
+      Last : Natural;
+   begin
+      while not End_Of_File (File) loop
+         Get_Line (File, Line, Last);
+
+         if Last /= 0
+           and then (Last = 1 or else Line (1 .. 2) /= "--")
+         then
+            declare
+               Candidate : Paths.Path
+                 := Paths.Path (Line (1 .. Last)) / Paths.Path (Name);
+            begin
+               if Candidate.Is_Regular_File then
+                  return Candidate;
+               end if;
+            end;
+         end if;
+      end loop;
+
+      return Paths.Null_Path;
+   end Test_Candidates;
+
+   function Locate_From_Path_File_Env
+     (Env_Var : String; Name : String) return Paths.Path is
+     -- Locate file called Name from the lines of a given file.
+     -- The file containing the lines has its name in the environment
+     -- variable Env_Var, if this is unset, the null path is returned.
+      Env_Value : String_Access := Getenv (Env_Var);
+      File : File_Type;
+   begin
+      if Env_Value.all /= "" then
+         begin
+             Open (File, In_File, Env_Value.all);
+
+             declare
+                Found_Candidate : Paths.Path
+                  := Test_Candidates (File, Name);
+             begin
+                if Found_Candidate /= Paths.Null_Path then
+                   Close (File);
+                   Free (Env_Value);
+                   return Found_Candidate;
+                end if;
+             end;
+         exception
+            when others =>
+               Put_Line ("error reading " & Env_Value.all);
+         end;
+
+         if Is_Open (File) then
+             Close (File);
+         end if;
+      end if;
+      Free (Env_Value);
+
+      return Paths.Null_Path;
+   end Locate_From_Path_File_Env;
+
+   function Locate_From_Path_Env
+     (Env_Var : String; Name : String) return Paths.Path is
+     -- Locate file called Name from all the potential path in the
+     -- environment variable called Env_Var.
+     -- If this Env_Var is unset, the null path is returned.
+      Env_Value : String_Access := Getenv (Env_Var);
+   begin
+      if Env_Value.all /= "" then
+         declare
+            Found_Candidate : Paths.Path
+              := Test_Candidates (Env_Value.all, Name);
+         begin
+            if Found_Candidate /= Paths.Null_Path then
+               Free (Env_Value);
+               return Found_Candidate;
+            end if;
+         end;
+      end if;
+
+      Free (Env_Value);
+      return Paths.Null_Path;
+   end Locate_From_Path_Env;
+
+   -------------
+   -- Resolve --
+   -------------
+
+   function Resolve (Name : String) return Paths.Path
+   is
+   begin
+
+      declare
+         Candidate : Paths.Path
+           := Paths.Path (Ada.Directories.Current_Directory) / Paths.Path (Name);
+      begin
+         if Candidate.Is_Regular_File then
+            return Candidate;
+         end if;
+      end;
+    
+      declare
+         Candidate : Paths.Path
+           := Locate_From_Path_File_Env ("GPR_PROJECT_PATH_FILE", Name);
+      begin
+         if Candidate.Is_Regular_File then
+            return Candidate;
+         end if;
+      end;
+    
+      declare
+         Candidate : Paths.Path
+           := Locate_From_Path_Env ("GPR_PROJECT_PATH", Name);
+      begin
+         if Candidate.Is_Regular_File then
+            return Candidate;
+         end if;
+      end;
+    
+      declare
+         Candidate : Paths.Path
+           := Locate_From_Path_Env ("ADA_PROJECT_PATH", Name);
+      begin
+         if Candidate.Is_Regular_File then
+            return Candidate;
+         end if;
+      end;
+
+      return Paths.Null_Path;
+   end Resolve;
+
+end GPR.Env;

--- a/wrapper/src/gpr-env.ads
+++ b/wrapper/src/gpr-env.ads
@@ -2,7 +2,7 @@
 --                                                                          --
 --                         GNAT COMPILER COMPONENTS                         --
 --                                                                          --
---                         C U D A   B I N D I N G S                        --
+--                              G P R . E N V                               --
 --                                                                          --
 --                                 S p e c                                  --
 --                                                                          --
@@ -24,32 +24,13 @@
 ------------------------------------------------------------------------------
 
 with Paths;
-with Paths.Env;
-with GPR.Env;
-use all type Paths.Path;
+use type Paths.Path;
 
-package CUDA_Bindings is
+package GPR.Env is
 
-   function CUDA_Install return Paths.Path
-      --  Install directory of the CUDA wrapper
-      is
-     (Paths.Env.Command_Dir.Parent) with
-      Post => CUDA_Install'Result.Is_Directory;
-      --  command is $INSTALL/bin/cuda-gcc
+   function Resolve (Name : String) return Paths.Path
+      --  Resolve the GPR File that corresponds to the given name
+      --  Name can be a relative, absolute Path or just the file name
+      with Post => Resolve'Result = Paths.Null_Path or Resolve'Result.Is_Absolute;
 
-   Directory : constant Paths.Path := GPR.Env.Resolve ("cuda_device.gpr").Parent;
-   --  Directory containing the bindings and binding infos.
-
-   Version_File : constant Paths.Path := Directory / "version";
-   --  File containing the bindings version information
-
-   function Up_To_Date return Boolean;
-   --  Returns True iff
-   --    + Bindings exist
-   --    + They are up-to-date in regard to hardware and software
-
-   procedure Generate with
-      Post => Up_To_Date;
-      --  Generate the up-to-date bindings in the directory
-
-end CUDA_Bindings;
+end GPR.Env;

--- a/wrapper/src/gpr.ads
+++ b/wrapper/src/gpr.ads
@@ -2,7 +2,7 @@
 --                                                                          --
 --                         GNAT COMPILER COMPONENTS                         --
 --                                                                          --
---                         C U D A   B I N D I N G S                        --
+--                                  G P R                                   --
 --                                                                          --
 --                                 S p e c                                  --
 --                                                                          --
@@ -23,33 +23,5 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-with Paths;
-with Paths.Env;
-with GPR.Env;
-use all type Paths.Path;
-
-package CUDA_Bindings is
-
-   function CUDA_Install return Paths.Path
-      --  Install directory of the CUDA wrapper
-      is
-     (Paths.Env.Command_Dir.Parent) with
-      Post => CUDA_Install'Result.Is_Directory;
-      --  command is $INSTALL/bin/cuda-gcc
-
-   Directory : constant Paths.Path := GPR.Env.Resolve ("cuda_device.gpr").Parent;
-   --  Directory containing the bindings and binding infos.
-
-   Version_File : constant Paths.Path := Directory / "version";
-   --  File containing the bindings version information
-
-   function Up_To_Date return Boolean;
-   --  Returns True iff
-   --    + Bindings exist
-   --    + They are up-to-date in regard to hardware and software
-
-   procedure Generate with
-      Post => Up_To_Date;
-      --  Generate the up-to-date bindings in the directory
-
-end CUDA_Bindings;
+package GPR is
+end GPR;

--- a/wrapper/src/paths-env.adb
+++ b/wrapper/src/paths-env.adb
@@ -1,0 +1,55 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                            P A T H S . E N V                             --
+--                                                                          --
+--                                 B o d y                                  --
+--                                                                          --
+--          Copyright (C) 2010-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
+-- for  more details.  You should have  received  a copy of the GNU General --
+-- Public License  distributed with GNAT; see file COPYING3.  If not, go to --
+-- http://www.gnu.org/licenses for a complete copy of the license.          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with GNAT.OS_Lib;
+
+package body Paths.Env is
+
+   ------------------------
+   -- Resolve_Executable --
+   ------------------------
+
+   function Resolve_Executable (P : Path) return Path is
+   begin
+      if Paths.Contains_Separator (+P) then
+         --  Given a "real" path:
+         --  Relative paths are not accepted
+         --  by OS_Lib.Locate_Exec_On_Path
+         return P.Resolve;
+      end if;
+
+      --  Given just an executable name, locate it
+      declare
+         Ex : GNAT.OS_Lib.String_Access :=
+           GNAT.OS_Lib.Locate_Exec_On_Path (+P);
+         --  Will raise Access_Error in case it is not found
+      begin
+         return P : Path := Path (Ex.all) do
+            GNAT.OS_Lib.Free (Ex);
+         end return;
+      end;
+   end Resolve_Executable;
+
+end Paths.Env;

--- a/wrapper/src/paths-env.ads
+++ b/wrapper/src/paths-env.ads
@@ -1,0 +1,40 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                            P A T H S . E N V                             --
+--                                                                          --
+--                                 S p e c                                  --
+--                                                                          --
+--          Copyright (C) 2010-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
+-- for  more details.  You should have  received  a copy of the GNU General --
+-- Public License  distributed with GNAT; see file COPYING3.  If not, go to --
+-- http://www.gnu.org/licenses for a complete copy of the license.          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package Paths.Env is
+   --  Paths related to the $PATH POSIX environment variable
+
+   function Resolve_Executable (P : Path) return Path
+      --  Resolve the executable that corresponds to the given path
+      --  Path can be relative, absolute or just the executable name
+      with
+      Post => Resolve_Executable'Result.Is_Absolute;
+
+   function Command_Dir return Path
+   --  Root dir of the executed command
+   is
+     (Resolve_Executable (Path (Ada.Command_Line.Command_Name)).Parent);
+
+end Paths.Env;

--- a/wrapper/src/paths.ads
+++ b/wrapper/src/paths.ads
@@ -1,0 +1,73 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                                P A T H S                                 --
+--                                                                          --
+--                                 S p e c                                  --
+--                                                                          --
+--          Copyright (C) 1992-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
+-- for  more details.  You should have  received  a copy of the GNU General --
+-- Public License  distributed with GNAT; see file COPYING3.  If not, go to --
+-- http://www.gnu.org/licenses for a complete copy of the license.          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Command_Line;
+with GNAT.OS_Lib;
+with Ada.Directories;
+with Ada.Strings;       use Ada.Strings;
+with Ada.Strings.Fixed; use Ada.Strings.Fixed;
+with Ada.Strings.Unbounded;
+
+package Paths is
+   type Path is new String;
+
+   function "+" (P : Path) return String is (String (P));
+
+   function "+" (S : Ada.Strings.Unbounded.Unbounded_String) return Path is
+     (Path (Ada.Strings.Unbounded.To_String (S)));
+
+   function Is_Absolute (P : Path) return Boolean is
+     (GNAT.OS_Lib.Is_Absolute_Path (+P));
+
+   function Is_Directory (P : Path) return Boolean is
+     (GNAT.OS_Lib.Is_Directory (+P));
+
+   function Is_Regular_File (P : Path) return Boolean is
+     (GNAT.OS_Lib.Is_Regular_File (+P));
+
+   function Exists (P : Path) return Boolean is (Ada.Directories.Exists (+P));
+
+   function "/" (P1 : Path; P2 : Path) return Path is
+     (P1 & GNAT.OS_Lib.Directory_Separator & P2) with
+      Pre => not Is_Absolute (P2);
+
+   Directory_Separator_Str : constant String (1 .. 1) :=
+     (1 => GNAT.OS_Lib.Directory_Separator);
+
+   function Contains_Separator (S : String) return Boolean is
+     (Index (S, Directory_Separator_Str) /= 0);
+
+   function Parent (P : Path) return Path is
+     (P
+        (P'First ..
+             Index (+P, Directory_Separator_Str, Going => Backward) - 1)) with
+      Pre => Contains_Separator
+        (+P) -- no path separator, no parent
+      and P'Length > 1; --  single path separator, no parent
+
+   function Resolve (P : Path) return Path is
+     (Path (GNAT.OS_Lib.Normalize_Pathname (+P)));
+
+end Paths;

--- a/wrapper/src/paths.ads
+++ b/wrapper/src/paths.ads
@@ -33,6 +33,8 @@ with Ada.Strings.Unbounded;
 package Paths is
    type Path is new String;
 
+   Null_Path : constant Path := "";
+
    function "+" (P : Path) return String is (String (P));
 
    function "+" (S : Ada.Strings.Unbounded.Unbounded_String) return Path is

--- a/wrapper/src/subprocess.adb
+++ b/wrapper/src/subprocess.adb
@@ -1,0 +1,102 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                           S U B P R O C E S S                            --
+--                                                                          --
+--                                 B o d y                                  --
+--                                                                          --
+--          Copyright (C) 2010-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
+-- for  more details.  You should have  received  a copy of the GNU General --
+-- Public License  distributed with GNAT; see file COPYING3.  If not, go to --
+-- http://www.gnu.org/licenses for a complete copy of the license.          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+with GNAT;
+with GNAT.OS_Lib; use GNAT.OS_Lib;
+with Ada.Text_IO; use Ada.Text_IO;
+with Ada.Directories;
+
+package body Subprocess is
+
+   -----------
+   -- Spawn --
+   -----------
+
+   function Spawn (S : String; Args : Argument_List) return Integer is
+   begin
+      if Verbose then
+         Put ("+ " & S);
+
+         for J in Args'Range loop
+            Put (" " & Args (J).all);
+         end loop;
+
+         New_Line;
+      end if;
+
+      return GNAT.OS_Lib.Spawn (S, Args);
+   end Spawn;
+
+   ----------------------
+   -- Shell_Executable --
+   ----------------------
+
+   function Shell_Executable return String is
+      S_Acc : String_Access := Getenv ("SHELL");
+   begin
+      if S_Acc /= null then
+         return S : String := S_Acc.all do
+            Free (S_Acc);
+         end return;
+      else
+         return Default_Shell;
+      end if;
+   end Shell_Executable;
+
+   -----------
+   -- Shell --
+   -----------
+
+   function Shell (S : String; CWD : String := "") return Integer is
+
+      Ret        : Integer;
+      Prev_Dir   : String           := Ada.Directories.Current_Directory;
+      Change_Dir : constant Boolean := (CWD /= "");
+
+      Opt  : aliased String         := "-c";
+      Cmd  : aliased String         := S;
+      Args : constant Argument_List :=
+        (Opt'Unchecked_Access, Cmd'Unchecked_Access);
+
+   begin
+      if Change_Dir then
+         Ada.Directories.Set_Directory (CWD);
+         if Verbose then
+            Put_Line ("entering " & CWD);
+         end if;
+      end if;
+
+      Ret := Spawn (Shell_Executable, Args);
+
+      if Change_Dir then
+         Ada.Directories.Set_Directory (Prev_Dir);
+         if Verbose then
+            Put_Line ("leaving " & CWD);
+         end if;
+      end if;
+
+      return Ret;
+   end Shell;
+
+end Subprocess;

--- a/wrapper/src/subprocess.ads
+++ b/wrapper/src/subprocess.ads
@@ -1,0 +1,48 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT COMPILER COMPONENTS                         --
+--                                                                          --
+--                           S U B P R O C E S S                            --
+--                                                                          --
+--                                 S p e c                                  --
+--                                                                          --
+--          Copyright (C) 2010-2022, Free Software Foundation, Inc.         --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License --
+-- for  more details.  You should have  received  a copy of the GNU General --
+-- Public License  distributed with GNAT; see file COPYING3.  If not, go to --
+-- http://www.gnu.org/licenses for a complete copy of the license.          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+with GNAT.OS_Lib;
+with Paths;
+use type Paths.Path;
+
+package Subprocess is
+
+   Verbose : Boolean := False;
+
+   function Spawn
+     (S : String; Args : GNAT.OS_Lib.Argument_List) return Integer;
+   --  Call GNAT.OS_Lib.Spawn, taking Verbose glob into account
+
+   Default_Shell : constant String := "sh";
+
+   function Shell (S : String; CWD : String := "") return Integer;
+   --  Call a shell with the given command
+   --  the shell comes from the POSIX $SHELL environement variable
+
+   function Shell (S : String; CWD : Paths.Path) return Integer is
+     (Shell (S, CWD => +CWD));
+   --  Call a shell with the given command
+   --  the shell comes from the POSIX $SHELL environement variable
+
+end Subprocess;

--- a/wrapper/wrapper.gpr
+++ b/wrapper/wrapper.gpr
@@ -5,7 +5,7 @@ project Wrapper is
    for Main use ("gnatcuda_wrapper.adb") & project'Main;
 
    package Compiler is
-      for Switches ("ada") use ("-gnatX");
+      for Switches ("ada") use ("-gnatX", "-gnata");
    end Compiler;
 
 end Wrapper;


### PR DESCRIPTION
With this change the CUDA bindings version is checked at startup and
the corresponding bindings are generated if it does not correspond to
the local informations.

At the moment the only version information is that of gnatvsn, which
is pretty limited.

$CUDA_ROOT should be specified so that the binding script works properly.
By default it uses /usr/local/cuda which is unfit for Windows.