### PR TITLE
gnatcuda_wrapper.adb: don't attempt linkage if -v is only switch

### DIFF
--- a/wrapper/src/gnatcuda_wrapper.adb
+++ b/wrapper/src/gnatcuda_wrapper.adb
@@ -158,6 +158,7 @@ function GNATCUDA_Wrapper return Integer is
 
    LLVM_Arg_Number : Integer := 0;
    Compile   : Boolean := False;
+   Link      : Boolean := True;
    Verbose   : Boolean := False;
 
    Prefix_LLVM_ARGS : constant Argument_List :=
@@ -286,6 +287,9 @@ begin
             Verbose := True;
             LLVM_Arg_Number := @ + 1;
             LLVM_Args (LLVM_Arg_Number) := new String'(Argument (J));
+            --  Only attempt compilation/linkage if -v isn't the sole argument
+            Compile := Argument_Count > 1;
+            Link := Argument_Count > 1;
          elsif Get_Argument (Arg, "-mcpu=sm_", Sub_Arg) then
             GPU_Name := new String'(To_String (Sub_Arg));
          elsif Get_Argument (Arg, "-mcuda-libdevice=", Sub_Arg) then
@@ -374,7 +378,7 @@ begin
             end if;
          end;
       end if;
-   else
+   elsif Link then
       declare
          Kernel_Object : constant String := Input_Files (1).all;
          Kernel_Fat : constant String := Kernel_Object


### PR DESCRIPTION
This fixes a crash that would happen when attempting to compile vector_sqrt.