### PR TITLE
fix example gpr files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ library project Device is
    Cubin_Version : Cubin_Version_Option := external ("cubin_version", "sm_75");
    
    package Compiler is
-      for Switches ("ada") use ("--RTS=../lib/rts-device-cuda", "-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);          
+      for Switches ("ada") use ("-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);          
    end Compiler;
 
    type Host_Target_Option is ("x86_64-linux", "aarch64-linux");

--- a/examples/0_Simple/simpleStreams/device.gpr
+++ b/examples/0_Simple/simpleStreams/device.gpr
@@ -18,7 +18,7 @@ library project Device is
    Cubin_Version : Cubin_Version_Option := external ("cubin_version", "sm_75");
    
    package Compiler is
-      for Switches ("ada") use ("--RTS=../lib/rts-device-cuda", "-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);     
+      for Switches ("ada") use ("-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);     
    end Compiler;
 
    type Host_Target_Option is ("x86_64-linux", "aarch64-linux");

--- a/examples/0_Simple/vectorAdd/device.gpr
+++ b/examples/0_Simple/vectorAdd/device.gpr
@@ -18,7 +18,7 @@ library project Device is
    Cubin_Version : Cubin_Version_Option := external ("cubin_version", "sm_75");
    
    package Compiler is
-      for Switches ("ada") use ("--RTS=../lib/rts-device-cuda", "-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);    
+      for Switches ("ada") use ("-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);    
    end Compiler;
 
    type Host_Target_Option is ("x86_64-linux", "aarch64-linux");

--- a/examples/0_Simple/vectorAdd_linked/device.gpr
+++ b/examples/0_Simple/vectorAdd_linked/device.gpr
@@ -16,7 +16,7 @@ library project Device is
    Cubin_Version : Cubin_Version_Option := external ("cubin_version", "sm_75");
    
    package Compiler is
-      for Switches ("ada") use ("--RTS=../lib/rts-device-cuda", "-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);   
+      for Switches ("ada") use ("-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);   
    end Compiler;
 
    type Host_Target_Option is ("x86_64-linux", "aarch64-linux");

--- a/examples/0_Simple/vectorSqrt/device.gpr
+++ b/examples/0_Simple/vectorSqrt/device.gpr
@@ -18,7 +18,7 @@ library project Device is
    Cubin_Version : Cubin_Version_Option := external ("cubin_version", "sm_75");
    
    package Compiler is
-      for Switches ("ada") use ("--RTS=../lib/rts-device-cuda", "-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);      
+      for Switches ("ada") use ("-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);      
    end Compiler;
 
    type Host_Target_Option is ("x86_64-linux", "aarch64-linux");

--- a/examples/image_filtering/device.gpr
+++ b/examples/image_filtering/device.gpr
@@ -32,7 +32,7 @@ project Device is
    Cubin_Version : Cubin_Version_Option := external ("cubin_version", "sm_75");
    
    package Compiler is
-      for Switches ("ada") use ("--RTS=../lib/rts-device-cuda", "-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);      
+      for Switches ("ada") use ("-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);      
    end Compiler;
 
    type Host_Target_Option is ("x86_64-linux", "aarch64-linux");

--- a/examples/marching/device.gpr
+++ b/examples/marching/device.gpr
@@ -16,7 +16,7 @@ library project Device is
    Cubin_Version : Cubin_Version_Option := external ("cubin_version", "sm_75");
    
    package Compiler is
-      for Switches ("ada") use ("--RTS=../lib/rts-device-cuda", "-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);      
+      for Switches ("ada") use ("-gnatX", "-O2", "-gnatn", "-mcpu=" & Cubin_Version);      
    end Compiler;
 
    type Host_Target_Option is ("x86_64-linux", "aarch64-linux");


### PR DESCRIPTION
1) Needs latest **gnat** toolchain (gnat.xml) (24 june 2022)
2) Tested vectorSqrt and marching. Both device.gpr and full build works like a charm.