### PR TITLE
enable pointing to external/not packaged cuda_env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ wrapper: FORCE
 	@echo "======================= WRAPPER BUILDING"
 	@echo $(PATH)
 	gprbuild -p -P wrapper/wrapper.gpr
-	cp wrapper/obj/gnatcuda_wrapper install/bin/cuda-gcc
-	cp install/bin/cuda-gcc $(llvm_dir)/bin/cuda-gcc
+	cp ./wrapper/obj/gnatcuda_wrapper ./install/bin/cuda-gcc
+	cp ./install/bin/cuda-gcc $(llvm_dir)/bin/cuda-gcc
 
 runtime: libdevice.ads
 	@echo "======================= RUNTIME BUILDING"
@@ -35,8 +35,8 @@ libdevice.ads:
 
 install/bin:
 	@echo "======================= INSTALL SETUP"
-	mkdir install
-	mkdir install/bin
+	mkdir -p install
+	mkdir -p install/bin
 
 uninstall:
 	rm $(llvm_dir)/bin/cuda-gcc

--- a/env.sh
+++ b/env.sh
@@ -1,12 +1,13 @@
 NVCC=`which nvcc`
 export CUDA_ROOT=${NVCC%/*/*}
 
+CUDA_ENV="$PWD/.."
 ROOT="$PWD/.."
 
-export GPR_PROJECT_PATH="$ROOT/cuda/api/:$ROOT/uwrap/lang_template/build:$ROOT/uwrap/lang_test/build:$ROOT/gnat-llvm/share/gpr:$GPR_PROJECT_PATH"
-export PYTHONPATH="$ROOT/uwrap/lang_template/build/python:$ROOT/uwrap/lang_test/build/python:$PYTHONPATH"
-export LD_LIBRARY_PATH="$ROOT/uwrap/lang_template/build/lib/relocatable/dev:$ROOT/uwrap/lang_test/build/lib/relocatable/dev:$ROOT/gnat-llvm/lib:$LD_LIBRARY_PATH"
-export PATH="$ROOT/uwrap/bin:$ROOT/uwrap/lang_template/build/lib/relocatable/dev:$ROOT/uwrap/lang_template/build/obj-mains:$ROOT/uwrap/lang_template/build/scripts:$ROOT/uwrap/lang_test/build/lib/relocatable/dev:$ROOT/uwrap/lang_test/build/obj-mains:$ROOT/uwrap/lang_test/build/scripts:$ROOT/gnat-llvm/bin:$PATH"
-export C_INCLUDE_PATH="$ROOT/uwrap/lang_template/build:$ROOT/uwrap/lang_test/build:$C_INCLUDE_PATH"
-export DYLD_LIBRARY_PATH="$ROOT/uwrap/lang_template/build/lib/relocatable/dev:$ROOT/uwrap/lang_test/build/lib/relocatable/dev:$DYLD_LIBRARY_PATH"
-export MYPYPATH="$ROOT/uwrap/lang_template/build/python:$ROOT/uwrap/lang_test/build/python:$MYPYPATH"
+export GPR_PROJECT_PATH="$ROOT/api/:$CUDA_ENV/uwrap/lang_template/build:$CUDA_ENV/uwrap/lang_test/build:$CUDA_ENV/gnat-llvm/share/gpr:$GPR_PROJECT_PATH"
+export PYTHONPATH="$CUDA_ENV/uwrap/lang_template/build/python:$CUDA_ENV/uwrap/lang_test/build/python:$PYTHONPATH"
+export LD_LIBRARY_PATH="$CUDA_ENV/uwrap/lang_template/build/lib/relocatable/dev:$CUDA_ENV/uwrap/lang_test/build/lib/relocatable/dev:$CUDA_ENV/gnat-llvm/lib:$LD_LIBRARY_PATH"
+export PATH="$CUDA_ENV/llvm-ads/bin:$CUDA_ENV/uwrap/bin:$CUDA_ENV/uwrap/lang_template/build/lib/relocatable/dev:$CUDA_ENV/uwrap/lang_template/build/obj-mains:$CUDA_ENV/uwrap/lang_template/build/scripts:$CUDA_ENV/uwrap/lang_test/build/lib/relocatable/dev:$CUDA_ENV/uwrap/lang_test/build/obj-mains:$CUDA_ENV/uwrap/lang_test/build/scripts:$CUDA_ENV/gnat-llvm/bin:$PATH"
+export C_INCLUDE_PATH="$CUDA_ENV/uwrap/lang_template/build:$CUDA_ENV/uwrap/lang_test/build:$C_INCLUDE_PATH"
+export DYLD_LIBRARY_PATH="$CUDA_ENV/uwrap/lang_template/build/lib/relocatable/dev:$CUDA_ENV/uwrap/lang_test/build/lib/relocatable/dev:$DYLD_LIBRARY_PATH"
+export MYPYPATH="$CUDA_ENV/uwrap/lang_template/build/python:$CUDA_ENV/uwrap/lang_test/build/python:$MYPYPATH"


### PR DESCRIPTION
Heads up on why/when to change the script vars  (ROOT, CUDA_ENV) will be part of the doc/readme commit.