### PR TITLE
bind.sh: Check env as pre-condition

### DIFF
--- a/api/bind.sh
+++ b/api/bind.sh
@@ -1,5 +1,6 @@
 set -ex
 export CUDA_PATH=$CUDA_ROOT/include/
+test -d "$CUDA_PATH"
 
 rm -rf host device
 


### PR DESCRIPTION
- Fix env.sh sourcing
- bind: precondition: /usr/local/cuda-11.6/inclide is a directory
