### PR TITLE
Sphinx default theme and template fix

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,9 +12,11 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+MAKEFILE = Makefile $(shell pwd)/Makefile
+
+.PHONY: help $(MAKEFILE)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+%: $(MAKEFILE)
+	$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Default sphinx template does not play well with the e3.anod.helper.Make, since it is using the `-f` option, which causes havoc on the template.

- Template fix (https://github.com/sphinx-doc/sphinx/pull/10707)
- Read the docs theme (https://docs.google.com/document/d/1wTX3Cvf09FVZDattqNSlVQZH0jTlD0vS4NaYhE3UjHE/edit#)