### PR TITLE
Fixed SAL handing.

### DIFF
--- a/api/cuda_api_device.gpr
+++ b/api/cuda_api_device.gpr
@@ -1,9 +1,11 @@
-project CUDA_API_Device is
+library project CUDA_API_Device is
    type CUDA_Host_Option is ("x86_64-linux", "aarch64-linux");
    CUDA_Host : CUDA_Host_Option := external ("cuda_host", "x86_64-linux");
 
    for Source_Dirs use ("device_static");
 
+   for Library_Name use "cuda_api_device";
+   for Library_Dir use "lib";
    for Object_Dir use "obj";
 
    for Target use "cuda";

--- a/examples/0_Simple/vectorAdd_elab/device.gpr
+++ b/examples/0_Simple/vectorAdd_elab/device.gpr
@@ -9,7 +9,7 @@ library project Device is
    for Object_Dir use "obj/device";
 
    for Target use "cuda";
-   for Library_Name use "kernel";
+   for Library_Name use "device";
    for Library_Dir use "lib";
    for Library_Standalone use "encapsulated";
    for Library_Kind use "dynamic";

--- a/examples/0_Simple/vectorAdd_elab/device.gpr
+++ b/examples/0_Simple/vectorAdd_elab/device.gpr
@@ -1,4 +1,4 @@
-with "cuda_api_device.gpr";
+with "cuda_api_device";
 
 library project Device is
 
@@ -10,7 +10,7 @@ library project Device is
 
    for Target use "cuda";
    for Library_Name use "kernel";
-   for Library_Dir use "lib/device_code";
+   for Library_Dir use "lib";
    for Library_Standalone use "encapsulated";
    for Library_Kind use "dynamic";
 

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -2,5 +2,5 @@ GPU_ARCH=sm_75
 CUDA_HOST=x86_64-linux
 
 example_build:
-	gprbuild -f -Xcuda_host=$(CUDA_HOST) -Xgpu_arch=$(GPU_ARCH) -P device 
-	gprbuild -f -Xcuda_host=$(CUDA_HOST) -P host -largs $(CURDIR)/lib/*.fatbin.o
+	gprbuild -f -v -Xcuda_host=$(CUDA_HOST) -Xgpu_arch=$(GPU_ARCH) -P device --db- --db $(HOME)/cuda/examples/db -largs -mcpu=$(GPU_ARCH) --shared
+	gprbuild -f -v -Xcuda_host=$(CUDA_HOST) -P host -largs $(CURDIR)/lib/*.fatbin.o

--- a/examples/Makefile.include
+++ b/examples/Makefile.include
@@ -2,5 +2,5 @@ GPU_ARCH=sm_75
 CUDA_HOST=x86_64-linux
 
 example_build:
-	gprbuild -f -v -Xcuda_host=$(CUDA_HOST) -Xgpu_arch=$(GPU_ARCH) -P device --db- --db $(HOME)/cuda/examples/db -largs -mcpu=$(GPU_ARCH) --shared
-	gprbuild -f -v -Xcuda_host=$(CUDA_HOST) -P host -largs $(CURDIR)/lib/*.fatbin.o
+	gprbuild -f -Xcuda_host=$(CUDA_HOST) -Xgpu_arch=$(GPU_ARCH) -P device -largs -mcpu=$(GPU_ARCH) --shared
+	gprbuild -f -Xcuda_host=$(CUDA_HOST) -P host -largs $(CURDIR)/lib/*.fatbin.o

--- a/wrapper/src/gnatcuda_wrapper.adb
+++ b/wrapper/src/gnatcuda_wrapper.adb
@@ -487,7 +487,7 @@ begin
                --  object files when it comes to binder files. As a temporary
                --  hack, changing the suffix here.
                Input_Files (Input_File_Number) :=
-                 new String'(Arg (Arg'First .. Arg'Last - 2) & ".cubin");
+                 new String'(Arg (Arg'First .. Arg'Last - 2) & ".s");
             else
                Input_Files (Input_File_Number) :=
                  new String'(Arg);


### PR DESCRIPTION
This patches changes the way the compilation and library build sequence. Compilation now stops at the production of the assembly file, linking a static library results in a cubin, linking a dynamic library will result in a fatbinary, to be included in a host main.

TN: VA19-044