### PR TITLE
`setup.sh` may autodetect the GPU by using new `nvidia-smi` command

### DIFF
--- a/compute_capability.sh
+++ b/compute_capability.sh
@@ -1,0 +1,56 @@
+set -e
+
+usage() {
+    echo "usage: $(basename $0) [--expect-single | -s] [--no-expect-single | -S] [--compute-prefix | -c] [--sm-prefix | -C]"
+}
+
+expect_single=0
+compute_prefix=1
+while [ ! -z $1 ]; do
+    case $1 in
+    -c|--compute-prefix)
+        compute_prefix=1
+        ;;
+    -C|--sm-prefix)
+        compute_prefix=0
+        ;;
+    -s|--expect-single)
+        expect_single=1
+        ;;
+    -S|--no-expect-single)
+        expect_single=0
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "unknown arg $1" >&2
+        usage
+        exit 2
+        ;;
+    esac
+
+    shift
+done
+
+cap=$(nvidia-smi --query-gpu=compute_cap --format=csv | tail -n +2 | tr -d .)
+number=$(echo "$cap" | wc -l)
+
+# number of GPU
+if [ $expect_single -eq 0 ]; then
+    echo "$number GPU"
+elif [ $number -ne 1 ]; then
+    echo "expected a single GPU, found $number" >&2
+    exit 1
+fi
+
+# capacity
+echo "$cap" | while read c; do
+    if [ $compute_prefix -eq 0 ]; then
+        prefix="sm_"
+    else
+        prefix="compute_"
+    fi
+    echo "$prefix$c"
+done

--- a/compute_capability.sh
+++ b/compute_capability.sh
@@ -34,8 +34,13 @@ while [ ! -z $1 ]; do
     shift
 done
 
-cap=$(nvidia-smi --query-gpu=compute_cap --format=csv | tail -n +2 | tr -d .)
-number=$(echo "$cap" | wc -l)
+csv=$(nvidia-smi --query-gpu=compute_cap --format=csv)
+cap=$(echo "$csv" | tail -n +2 | tr -d '. \t')
+if [ -z "$cap" ]; then
+    number=0
+else
+    number=$(echo "$cap" | wc -l)
+fi
 
 # number of GPU
 if [ $expect_single -eq 0 ]; then
@@ -46,11 +51,13 @@ elif [ $number -ne 1 ]; then
 fi
 
 # capacity
-echo "$cap" | while read c; do
-    if [ $compute_prefix -eq 0 ]; then
-        prefix="sm_"
-    else
-        prefix="compute_"
-    fi
-    echo "$prefix$c"
-done
+if [ $number -ne 0 ]; then
+    echo "$cap" | while read c; do
+        if [ $compute_prefix -eq 0 ]; then
+            prefix="sm_"
+        else
+            prefix="compute_"
+        fi
+        echo "$prefix$c"
+    done
+fi


### PR DESCRIPTION
Add the `compute_capability.sh` script which detects and counts the GPU on the machine, based on NVIDIA's `nvidia-smi` (https://stackoverflow.com/a/71489432)

The `-mcpu` option becomes optional, in which case the `compute_capability.sh` script is used to try to find a **single** GPU on the machine, which can fail if there is 0 or 2+ GPU, or if `nvidia-smi` is not callable with the option (cuda tool kit <11.6)

Also add a check that `setup.sh` is run from the proper directory (was already a prerequisite due to calling `./env`) and a `fatal()` routine in the script