### PR TITLE
Remove unused rules from example Makefiles

### DIFF
--- a/examples/0_Simple/simpleStreams/Makefile
+++ b/examples/0_Simple/simpleStreams/Makefile
@@ -1,3 +1,1 @@
 include ../../../Makefile.build
-
-build: example_build

--- a/examples/0_Simple/vectorAdd/Makefile
+++ b/examples/0_Simple/vectorAdd/Makefile
@@ -1,3 +1,1 @@
 include ../../../Makefile.build
-
-build: gnatcuda_build


### PR DESCRIPTION
I can't find where these rules are used. If they are a leftover from a previous iteration, I propose to remove them.