### PR TITLE
Handle new definition of cudaGetDeviceProperties

### DIFF
--- a/api/cuda-host.wrp
+++ b/api/cuda-host.wrp
@@ -33,6 +33,9 @@ wrap w_DefiningName (normalize_ada_name ("\1") & "_\2_" & normalize_ada_name ("\
 match DefiningName (x"^cuda(.*[a-zA-Z])([1-3]D)$")
 wrap w_DefiningName (normalize_ada_name ("\1") & "_\2");
 
+match DefiningName (x"^cuda(.*)_v2$")
+wrap w_DefiningName (normalize_ada_name ("\1"));
+
 #TODO I should be able to write match DefiningName (x"^p([A-Z].*)$" and not x"pType")
 match DefiningName (x"^p([A-Z].*)$") and not DefiningName (x"pType")
 wrap w_DefiningName (normalize_ada_name ("\1"));


### PR DESCRIPTION
I welcome suggestion on how to make this cleaner, and I would also appreciate if someone checked that things aren't broken with CUDA < 12.0. I dont feel adventurous enough to downgrade.