### PR TITLE
Restrict the scope of "_v2" symbol transformation

### DIFF
--- a/api/cuda-host.wrp
+++ b/api/cuda-host.wrp
@@ -33,7 +33,7 @@ wrap w_DefiningName (normalize_ada_name ("\1") & "_\2_" & normalize_ada_name ("\
 match DefiningName (x"^cuda(.*[a-zA-Z])([1-3]D)$")
 wrap w_DefiningName (normalize_ada_name ("\1") & "_\2");
 
-match DefiningName (x"^cuda(.*)_v2$")
+match DefiningName (x"^cuda(GetDeviceProperties)_v2$")
 wrap w_DefiningName (normalize_ada_name ("\1"));
 
 #TODO I should be able to write match DefiningName (x"^p([A-Z].*)$" and not x"pType")


### PR DESCRIPTION
I've checked that the simpleStreams sample still compile with this UWrap modifications and CUDA 12.0.